### PR TITLE
created deploy.yml to auto pull on the server

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,19 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    name: Deploy to production
+    runs-on: self-hosted
+
+    steps:
+      - name: Deploy
+        run: |
+          cd /srv/repos/viernulvier-5
+          git pull origin main
+          docker compose up -d --build
+          docker compose exec app npx prisma migrate deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,4 +16,4 @@ jobs:
           cd /srv/repos/viernulvier-5
           git pull origin main
           docker compose up -d --build
-          docker compose exec app npx prisma migrate deploy
+          docker compose exec vnv_backend npx prisma migrate deploy


### PR DESCRIPTION
<!--
  Thanks for opening a pull request!
  Fill in the sections below to help reviewers understand your changes quickly.
  Delete any section that genuinely does not apply.
-->

#### 🔗 Related Issue

Closes #63 <!-- issue number -->
Type: Feature<!-- What was the type of that issue? -->

___
#### 🐛 Description of Issue

<!--
  Briefly describe what the issue was that this PR solves.
  A reviewer should be able to understand the "why" without having to read the issue first.
-->

The Issue was a request to automatically pull the newest version of main in the server.

___
#### 🔧 What Has Changed

<!--
  Summarise the changes you made. Focus on WHAT changed, not HOW
  (the code speaks for itself). Bullet points work well here.
-->

- deploy.yml was made under .github/workflows


___
#### 🏗️ Design Choices

<!--
  Explain the non-obvious decisions you made and why you made them.
  Were there alternatives you considered and rejected? Mention them here
  so reviewers understand the tradeoffs and do not suggest paths you already explored.
-->

- I branched from the branch db-server-setup, this was because it contained a docker-compose.yml that included a field `restart: unless-stopped`. That way i didn't need to add `docker compose exec app npm run start`.

___
#### 🧪 Testing

<!--
  Describe how this change has been tested.
  Check all that apply.
-->

- [x] I couldn't really test this. We will have to see if the server actually pulls automatically. If not, we should reopen this PR and fix it. It will also only start working when this PR is merged into main.

___
#### ✅ Pre-merge Checklist

<!--
  Go through this checklist before marking the PR as ready for review.
  All boxes must be checked before merging (the branch protection rules will enforce most of these,
  but this checklist serves as a reminder and a paper trail).
-->

- [x] Linked to a related issue above
- [x] My code follows the project's code style (`npm run lint` passes)
- [x] All existing tests still pass (`npm test` passes)
- [x] New functionality is covered by tests (or wasn't needed: explained!)
- [x] I have reviewed my own diff before requesting review
- [x] At least 2 reviewers have been assigned (auto-assigned, but verify)

