### PR TITLE
fixing the example.com problem

### DIFF
--- a/backend/src/modules/auth/auth.schema.ts
+++ b/backend/src/modules/auth/auth.schema.ts
@@ -11,7 +11,7 @@ export const loginSchema = z.object({
  */
 export const authLinksSchema = z.object({
     self: z.string().url().default('https://example.com/'),
-    logout: z.string().url().optional().default('https://example.com/'),
+    logout: z.string().url().optional().nullable().default('https://example.com/'),
 })
 
 export const userSchema = z.object({

--- a/backend/src/modules/events/events.controller.ts
+++ b/backend/src/modules/events/events.controller.ts
@@ -23,8 +23,8 @@ export class EventsController {
             ...event,
             links: {
                 self: `${baseUrl}/events/${event.id}`,
-                production: event.production_id ? `${baseUrl}/productions/${event.production_id}` : undefined,
-                hall: event.hall_id ? `${baseUrl}/halls/${event.hall_id}` : undefined,
+                production: event.production_id ? `${baseUrl}/productions/${event.production_id}` : null,
+                hall: event.hall_id ? `${baseUrl}/halls/${event.hall_id}` : null,
                 prices: `${baseUrl}/events/prices?eventId=${event.id}`,
             }
         }
@@ -35,7 +35,7 @@ export class EventsController {
             ...price,
             links: {
                 self: `${baseUrl}/events/prices/${price.id}`,
-                event: price.event_id ? `${baseUrl}/events/${price.event_id}` : undefined,
+                event: price.event_id ? `${baseUrl}/events/${price.event_id}` : null,
             }
         }
     }

--- a/backend/src/modules/events/events.schema.ts
+++ b/backend/src/modules/events/events.schema.ts
@@ -30,9 +30,9 @@ export const eventPricePaginationQuerySchema = z.object({
  */
 export const eventLinksSchema = z.object({
     self: z.string().url().default('https://example.com/'),
-    production: z.string().url().optional().default('https://example.com/'),
-    hall: z.string().url().optional().default('https://example.com/'),
-    prices: z.string().url().optional().default('https://example.com/'),
+    production: z.string().url().optional().nullable().default('https://example.com/'),
+    hall: z.string().url().optional().nullable().default('https://example.com/'),
+    prices: z.string().url().optional().nullable().default('https://example.com/'),
 })
 
 export const eventSchema = z.object({
@@ -68,7 +68,7 @@ export const singleEventSchema = createSingleResponseSchema(eventSchema)
  */
 export const eventPriceLinksSchema = z.object({
     self: z.string().url().default('https://example.com/'),
-    event: z.string().url().optional().default('https://example.com/'),
+    event: z.string().url().optional().nullable().default('https://example.com/'),
 })
 
 export const eventPriceSchema = z.object({

--- a/backend/src/modules/halls/halls.controller.ts
+++ b/backend/src/modules/halls/halls.controller.ts
@@ -21,7 +21,7 @@ export class HallsController {
             ...hall,
             links: {
                 self: `${baseUrl}/halls/${hall.id}`,
-                space: hall.space_id ? `${baseUrl}/spaces/${hall.space_id}` : undefined,
+                space: hall.space_id ? `${baseUrl}/spaces/${hall.space_id}` : null,
                 events: `${baseUrl}/events?hallId=${hall.id}`,
             }
         }

--- a/backend/src/modules/halls/halls.schema.ts
+++ b/backend/src/modules/halls/halls.schema.ts
@@ -23,8 +23,8 @@ export const hallPaginationQuerySchema = z.object({
  */
 export const hallLinksSchema = z.object({
     self: z.string().url().default('https://example.com/'),
-    space: z.string().url().optional().default('https://example.com/'),
-    events: z.string().url().optional().default('https://example.com/'),
+    space: z.string().url().optional().nullable().default('https://example.com/'),
+    events: z.string().url().optional().nullable().default('https://example.com/'),
 })
 
 export const hallSchema = z.object({

--- a/backend/src/modules/locations/locations.schema.ts
+++ b/backend/src/modules/locations/locations.schema.ts
@@ -22,7 +22,7 @@ export const locationPaginationQuerySchema = z.object({
  */
 export const locationLinksSchema = z.object({
     self: z.string().url().default('https://example.com/'),
-    spaces: z.string().url().optional().default('https://example.com/'),
+    spaces: z.string().url().optional().nullable().default('https://example.com/'),
 })
 
 export const locationSchema = z.object({

--- a/backend/src/modules/media/media.controller.ts
+++ b/backend/src/modules/media/media.controller.ts
@@ -39,7 +39,7 @@ export class MediaController {
             ...item,
             links: {
                 self: `${baseUrl}/items/${item.id}`,
-                gallery: item.gallery_id ? `${baseUrl}/galleries/${item.gallery_id}` : undefined,
+                gallery: item.gallery_id ? `${baseUrl}/galleries/${item.gallery_id}` : null,
                 crops: `${baseUrl}/items/crops?itemId=${item.id}`,
             }
         }
@@ -50,7 +50,7 @@ export class MediaController {
             ...crop,
             links: {
                 self: `${baseUrl}/items/crops/${crop.id}`,
-                item: crop.item_id ? `${baseUrl}/items/${crop.item_id}` : undefined,
+                item: crop.item_id ? `${baseUrl}/items/${crop.item_id}` : null,
             }
         }
     }

--- a/backend/src/modules/media/media.schema.ts
+++ b/backend/src/modules/media/media.schema.ts
@@ -30,7 +30,7 @@ export const cropPaginationQuerySchema = galleryPaginationQuerySchema.extend({
  */
 export const galleryLinksSchema = z.object({
     self: z.string().url().default('https://example.com/'),
-    items: z.string().url().optional().default('https://example.com/'),
+    items: z.string().url().optional().nullable().default('https://example.com/'),
 })
 
 export const gallerySchema = z.object({
@@ -47,8 +47,8 @@ export const gallerySchema = z.object({
  */
 export const itemLinksSchema = z.object({
     self: z.string().url().default('https://example.com/'),
-    gallery: z.string().url().optional().default('https://example.com/'),
-    crops: z.string().url().optional().default('https://example.com/'),
+    gallery: z.string().url().optional().nullable().default('https://example.com/'),
+    crops: z.string().url().optional().nullable().default('https://example.com/'),
 })
 
 export const itemSchema = z.object({
@@ -75,7 +75,7 @@ export const itemSchema = z.object({
  */
 export const cropLinksSchema = z.object({
     self: z.string().url().default('https://example.com/'),
-    item: z.string().url().optional().default('https://example.com/'),
+    item: z.string().url().optional().nullable().default('https://example.com/'),
 })
 
 export const cropSchema = z.object({

--- a/backend/src/modules/productions/productions.controller.ts
+++ b/backend/src/modules/productions/productions.controller.ts
@@ -23,11 +23,11 @@ export class ProductionsController {
             links: {
                 self: `${baseUrl}/productions/${prodId}`,
                 events: `${baseUrl}/events?production_id=${prodId}`,
-                media_gallery: production.media_gallery_id ? `${baseUrl}/media/galleries/${production.media_gallery_id}` : undefined,
-                review_gallery: production.review_gallery_id ? `${baseUrl}/media/galleries/${production.review_gallery_id}` : undefined,
-                poster_gallery: production.poster_gallery_id ? `${baseUrl}/media/galleries/${production.poster_gallery_id}` : undefined,
-                uitdatabank_theme: production.uitdatabank_theme ? `${baseUrl}/uitdatabank/themes/${production.uitdatabank_theme}` : undefined,
-                uitdatabank_type: production.uitdatabank_type ? `${baseUrl}/uitdatabank/types/${production.uitdatabank_type}` : undefined,
+                media_gallery: production.media_gallery_id ? `${baseUrl}/media/galleries/${production.media_gallery_id}` : null,
+                review_gallery: production.review_gallery_id ? `${baseUrl}/media/galleries/${production.review_gallery_id}` : null,
+                poster_gallery: production.poster_gallery_id ? `${baseUrl}/media/galleries/${production.poster_gallery_id}` : null,
+                uitdatabank_theme: production.uitdatabank_theme ? `${baseUrl}/uitdatabank/themes/${production.uitdatabank_theme}` : null,
+                uitdatabank_type: production.uitdatabank_type ? `${baseUrl}/uitdatabank/types/${production.uitdatabank_type}` : null,
             }
         }
     }

--- a/backend/src/modules/productions/productions.schema.ts
+++ b/backend/src/modules/productions/productions.schema.ts
@@ -22,12 +22,12 @@ export const paginationQuerySchema = z.object({
  */
 export const productionLinksSchema = z.object({
     self: z.string().url().default('https://example.com/'),
-    events: z.string().url().optional().default('https://example.com/'),
-    media_gallery: z.string().url().optional().default('https://example.com/'),
-    review_gallery: z.string().url().optional().default('https://example.com/'),
-    poster_gallery: z.string().url().optional().default('https://example.com/'),
-    uitdatabank_theme: z.string().url().optional().default('https://example.com/'),
-    uitdatabank_type: z.string().url().optional().default('https://example.com/'),
+    events: z.string().url().optional().nullable().default('https://example.com/'),
+    media_gallery: z.string().url().optional().nullable().default('https://example.com/'),
+    review_gallery: z.string().url().optional().nullable().default('https://example.com/'),
+    poster_gallery: z.string().url().optional().nullable().default('https://example.com/'),
+    uitdatabank_theme: z.string().url().optional().nullable().default('https://example.com/'),
+    uitdatabank_type: z.string().url().optional().nullable().default('https://example.com/'),
 })
 
 export const productionSchema = z.object({

--- a/backend/src/modules/spaces/spaces.controller.ts
+++ b/backend/src/modules/spaces/spaces.controller.ts
@@ -21,7 +21,7 @@ export class SpacesController {
             ...space,
             links: {
                 self: `${baseUrl}/spaces/${space.id}`,
-                location: space.location_id ? `${baseUrl}/locations/${space.location_id}` : undefined,
+                location: space.location_id ? `${baseUrl}/locations/${space.location_id}` : null,
                 halls: `${baseUrl}/halls?spaceId=${space.id}`,
             }
         }

--- a/backend/src/modules/spaces/spaces.schema.ts
+++ b/backend/src/modules/spaces/spaces.schema.ts
@@ -23,8 +23,8 @@ export const spacePaginationQuerySchema = z.object({
  */
 export const spaceLinksSchema = z.object({
     self: z.string().url().default('https://example.com/'),
-    location: z.string().url().optional().default('https://example.com/'),
-    halls: z.string().url().optional().default('https://example.com/'),
+    location: z.string().url().optional().nullable().default('https://example.com/'),
+    halls: z.string().url().optional().nullable().default('https://example.com/'),
 })
 
 export const spaceSchema = z.object({

--- a/backend/src/modules/taxonomies/taxonomies.controller.ts
+++ b/backend/src/modules/taxonomies/taxonomies.controller.ts
@@ -35,7 +35,7 @@ export class TaxonomiesController {
             ...tag,
             links: {
                 self: `${baseUrl}/tags/${tag.id}`,
-                gallery: tag.gallery_id ? `${baseUrl}/media/galleries/${tag.gallery_id}` : undefined,
+                gallery: tag.gallery_id ? `${baseUrl}/media/galleries/${tag.gallery_id}` : null,
             }
         }
     }

--- a/backend/src/modules/taxonomies/taxonomies.schema.ts
+++ b/backend/src/modules/taxonomies/taxonomies.schema.ts
@@ -24,7 +24,7 @@ export const tagPaginationQuerySchema = genrePaginationQuerySchema
  */
 export const genreLinksSchema = z.object({
     self: z.string().url().default('https://example.com/'),
-    productions: z.string().url().optional().default('https://example.com/'),
+    productions: z.string().url().optional().nullable().default('https://example.com/'),
 })
 
 export const genreSchema = z.object({
@@ -49,7 +49,7 @@ export const singleGenreSchema = createSingleResponseSchema(genreSchema)
  */
 export const tagLinksSchema = z.object({
     self: z.string().url().default('https://example.com/'),
-    gallery: z.string().url().optional().default('https://example.com/'),
+    gallery: z.string().url().optional().nullable().default('https://example.com/'),
 })
 
 export const tagSchema = z.object({

--- a/backend/src/modules/uitdatabank/uitdatabank.schema.ts
+++ b/backend/src/modules/uitdatabank/uitdatabank.schema.ts
@@ -15,7 +15,7 @@ export const uitdatabankPaginationQuerySchema = z.object({
  */
 export const keywordLinksSchema = z.object({
     self: z.string().url().default('https://example.com/'),
-    productions: z.string().url().optional().default('https://example.com/'),
+    productions: z.string().url().optional().nullable().default('https://example.com/'),
 })
 
 export const keywordSchema = z.object({
@@ -32,7 +32,7 @@ export const keywordSchema = z.object({
  */
 export const themeLinksSchema = z.object({
     self: z.string().url().default('https://example.com/'),
-    productions: z.string().url().optional().default('https://example.com/'),
+    productions: z.string().url().optional().nullable().default('https://example.com/'),
 })
 
 export const themeSchema = z.object({
@@ -50,7 +50,7 @@ export const themeSchema = z.object({
  */
 export const typeLinksSchema = z.object({
     self: z.string().url().default('https://example.com/'),
-    productions: z.string().url().optional().default('https://example.com/'),
+    productions: z.string().url().optional().nullable().default('https://example.com/'),
 })
 
 export const typeSchema = z.object({


### PR DESCRIPTION
<!--
  Thanks for opening a pull request!
  Fill in the sections below to help reviewers understand your changes quickly.
  Delete any section that genuinely does not apply.
-->

#### 🔗 Related Issue

Closes #115 
Type: Bug

___
#### 🐛 Description of Issue

<!--
  Briefly describe what the issue was that this PR solves.
  A reviewer should be able to understand the "why" without having to read the issue first.
-->

When getting data from the API, `undifiend` fields would become `https://example.com/`. This shouldn't happen because  this is ment to make the Swagger UI more readable.

___
#### 🔧 What Has Changed

<!--
  Summarise the changes you made. Focus on WHAT changed, not HOW
  (the code speaks for itself). Bullet points work well here.
-->

Instead of having fields `undifiend`, we give the value `null` to the field. This way there will be no value `https://example.com/` filled in as default

___
#### 🏗️ Design Choices

<!--
  Explain the non-obvious decisions you made and why you made them.
  Were there alternatives you considered and rejected? Mention them here
  so reviewers understand the tradeoffs and do not suggest paths you already explored.
-->

See previous point

___
#### Manual testing instructions:

To verify this issue is resolved, a reviewer should:
1. `npm run dev`
2. http://localhost:3001/docs
3. Check if everything works

___
#### ✅ Pre-merge Checklist

<!--
  Go through this checklist before marking the PR as ready for review.
  All boxes must be checked before merging (the branch protection rules will enforce most of these,
  but this checklist serves as a reminder and a paper trail).
-->

- [x] Linked to a related issue above
- [x] My code follows the project's code style (`npm run lint` passes)
- [x] All existing tests still pass (`npm test` passes)
- [x] New functionality is covered by tests (or wasn't needed: explained!)
- [x] I have reviewed my own diff before requesting review
- [x] At least 2 reviewers have been assigned (auto-assigned, but verify)

---

## 📸 Screenshots / Demo *(optional)*

<!-- If your change affects the UI, attach a before/after screenshot or a short screen recording. -->

