### PR TITLE
Scraper crop improvement

### DIFF
--- a/backend/src/scraper/scraper.ts
+++ b/backend/src/scraper/scraper.ts
@@ -898,7 +898,8 @@ async function sync_crops(cutoff_timestamp: Date | undefined = undefined){
     const page = filterByCutoff(rawPage, cutoff_timestamp);
 
     await prisma.$transaction(
-        page.map(crop =>
+        page.filter(crop => crop.name?.toLowerCase() === "fe3_header" || crop.name?.toLowerCase() == "fe3_boxed")
+            .map(crop =>
             prisma.crop.upsert({
               where: {apiId: crop["@id"]},
               update: mapCrop(crop),

--- a/backend/src/scraper/scraper.ts
+++ b/backend/src/scraper/scraper.ts
@@ -897,7 +897,6 @@ async function sync_crops(cutoff_timestamp: Date | undefined = undefined){
     if (rawPage.length === 0) break;
     const page = filterByCutoff(rawPage, cutoff_timestamp);
 
-
     await prisma.$transaction(
         page.filter(crop => crop.name?.toLowerCase() === "fe3_header" || crop.name?.toLowerCase() == "fe3_boxed")
             .map(crop =>

--- a/backend/src/scraper/scraper.ts
+++ b/backend/src/scraper/scraper.ts
@@ -897,6 +897,7 @@ async function sync_crops(cutoff_timestamp: Date | undefined = undefined){
     if (rawPage.length === 0) break;
     const page = filterByCutoff(rawPage, cutoff_timestamp);
 
+
     await prisma.$transaction(
         page.filter(crop => crop.name?.toLowerCase() === "fe3_header" || crop.name?.toLowerCase() == "fe3_boxed")
             .map(crop =>

--- a/backend/test/integration/scraper/scraper.test.ts
+++ b/backend/test/integration/scraper/scraper.test.ts
@@ -168,6 +168,18 @@ vi.mock('../../../src/scraper/fetcher', () => {
       "@type": "Crop",
       created_at: "2021-01-05T09:00:00Z",
       updated_at: "2021-01-06T09:30:00Z",
+      name: "FE3_header",
+      url: "https://example.com/crop-1.jpg",
+    } as APICrop,
+  ];
+
+  const other_crops: APICrop[] = [
+    {
+      "@context": "/api/context/crop",
+      "@id": "/crop/2",
+      "@type": "Crop",
+      created_at: "2021-01-05T09:00:00Z",
+      updated_at: "2021-01-06T09:30:00Z",
       name: "thumb",
       url: "https://example.com/crop-1.jpg",
     } as APICrop,
@@ -550,10 +562,15 @@ describe('scraper integration full coverage', () => {
   it('checks all crop fields', async () => {
     const crop = await prisma.crop.findUnique({ where: { apiId: '/crop/1' } });
     expect(crop).not.toBeNull();
-    expect(crop?.name).toBe('thumb');
+    expect(crop?.name).toBe('FE3_header');
     expect(crop?.url).toBe('https://example.com/crop-1.jpg');
     expect(crop?.created_at.toISOString()).toBe('2021-01-05T09:00:00.000Z');
     expect(crop?.updated_at.toISOString()).toBe('2021-01-06T09:30:00.000Z');
+  });
+
+  it('checks not downloaded crop fields', async () => {
+    const crop = await prisma.crop.findUnique({ where: { apiId: '/crop/2' } });
+    expect(crop).toBeNull();
   });
 
   it('checks all item fields and crop relation', async () => {


### PR DESCRIPTION


#### 🔗 Related Issue

Closes #<!-- issue number -->
Type: <!-- What was the type of that issue? -->

___
#### 🐛 Description of Issue

Since we're only using FE3_header and FE3_boxed the scraper should only save those


___
#### 🔧 What Has Changed


- simple edit so the scraper only takes fe3_header and fe3_boxed
___

#### 🧪 Testing

<!--
  Describe how this change has been tested.
  Check all that apply.
-->

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manually tested locally
- [ ] No tests needed — explain why: ...

___
#### Manual testing instructions:

To verify this issue is resolved, a reviewer should:
1. locally run the scraper and check if there are any crops that arent FE3_scraper or FE3_header


___
#### ✅ Pre-merge Checklist

<!--
  Go through this checklist before marking the PR as ready for review.
  All boxes must be checked before merging (the branch protection rules will enforce most of these,
  but this checklist serves as a reminder and a paper trail).
-->

- [ ] Linked to a related issue above
- [ ] My code follows the project's code style (`npm run lint` passes)
- [ ] All existing tests still pass (`npm test` passes)
- [ ] New functionality is covered by tests (or wasn't needed: explained!)
- [ ] I have reviewed my own diff before requesting review
- [ ] At least 2 reviewers have been assigned (auto-assigned, but verify)

---

## 📸 Screenshots / Demo *(optional)*

<!-- If your change affects the UI, attach a before/after screenshot or a short screen recording. -->

