### PR TITLE
Allow admin routes on sel2 host

### DIFF
--- a/frontend/src/admin/paths.ts
+++ b/frontend/src/admin/paths.ts
@@ -12,9 +12,10 @@ export function getAdminRouteConfig(hostname: string): AdminRouteConfig {
   const normalizedHostname = hostname.trim().toLowerCase()
   const isAdminHost = normalizedHostname.startsWith('admin.')
   const isLocalDevHost = normalizedHostname === 'localhost' || normalizedHostname === '127.0.0.1'
-  const canRenderAdminRoutes = isAdminHost || isLocalDevHost
+  const isPublicAdminHost = normalizedHostname === 'sel2-5.ugent.be'
+  const canRenderAdminRoutes = isAdminHost || isLocalDevHost || isPublicAdminHost
 
-  if (canRenderAdminRoutes) {
+  if (isAdminHost || isLocalDevHost) {
     return {
       isAdminHost,
       isLocalDevHost,
@@ -29,7 +30,7 @@ export function getAdminRouteConfig(hostname: string): AdminRouteConfig {
   return {
     isAdminHost,
     isLocalDevHost,
-    canRenderAdminRoutes: false,
+    canRenderAdminRoutes,
     loginPath: '/admin/login',
     dashboardPath: '/admin',
     legacyDashboardPaths: [],

--- a/frontend/src/test/admin/paths.test.ts
+++ b/frontend/src/test/admin/paths.test.ts
@@ -24,6 +24,17 @@ describe('getAdminRouteConfig', () => {
     })
   })
 
+  it('allows sel2-5.ugent.be to render admin routes without admin-host legacy routes', () => {
+    expect(getAdminRouteConfig('sel2-5.ugent.be')).toMatchObject({
+      canRenderAdminRoutes: true,
+      isAdminHost: false,
+      isLocalDevHost: false,
+      loginPath: '/admin/login',
+      dashboardPath: '/admin',
+      legacyDashboardPaths: [],
+    })
+  })
+
   it('disables admin routes on public hosts', () => {
     expect(getAdminRouteConfig('archief.viernulvier.be')).toMatchObject({
       canRenderAdminRoutes: false,


### PR DESCRIPTION
## Summary
- Allow the exact `sel2-5.ugent.be` host to render admin routes so `/admin` works on the deployed UGent domain.
- Keep admin-subdomain and localhost legacy dashboard aliases unchanged.
- Add a focused route-config regression test for the public UGent admin host.

## Test plan
- [x] `npm --prefix frontend test -- src/test/admin/paths.test.ts`
- [x] `npm --prefix frontend run build`