### PR TITLE
Use GitHub hosted instead of self hosted runners for actions

### DIFF
--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   assign-reviewers:
     name: Assign 2 random reviewers and notify on Discord
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     permissions:
       pull-requests: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   backend:
     name: Backend (Lint + Test)
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     services:
       postgres:
@@ -60,7 +60,7 @@ jobs:
 
   frontend:
     name: Frontend (Lint + Test + Build)
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     defaults:
       run:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   backend-coverage:
     name: Backend Coverage
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     services:
       postgres:
@@ -67,7 +67,7 @@ jobs:
 
   frontend-coverage:
     name: Frontend Coverage
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     permissions:
       contents: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   deploy:
     name: Deploy to production
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
       - name: Deploy

--- a/.github/workflows/discord-notify-on-changes-requested.yml
+++ b/.github/workflows/discord-notify-on-changes-requested.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   notify-changes-requested:
     name: Notify when changes are requested
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     permissions:
       pull-requests: read

--- a/.github/workflows/discord-notify-on-re-request-review.yml
+++ b/.github/workflows/discord-notify-on-re-request-review.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   notify:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     permissions:
       pull-requests: read

--- a/.github/workflows/discord-notify-on-ready-for-review.yml
+++ b/.github/workflows/discord-notify-on-ready-for-review.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   notify:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     permissions:
       pull-requests: read

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -231,7 +231,7 @@ Also update:
 - Coverage CI: `.github/workflows/coverage.yml`
   - Backend and frontend Vitest coverage
   - Coverage comments posted to PR
-- Runners: self-hosted
+- Runners: ubuntu-latest
 
 Do not change CI workflows unless the task explicitly includes CI changes.
 

--- a/frontend/src/test/blogs/blogDetailPage.test.tsx
+++ b/frontend/src/test/blogs/blogDetailPage.test.tsx
@@ -25,7 +25,8 @@ vi.mock('quill', () => {
       root: HTMLDivElement
 
       constructor(container: HTMLDivElement) {
-        this.root = container
+        this.root = document.createElement('div')
+        container.appendChild(this.root)
       }
 
       setContents(delta: { ops?: Array<{ insert?: unknown }> }) {
@@ -33,7 +34,7 @@ vi.mock('quill', () => {
           ? delta.ops
               .map((op) => (typeof op.insert === 'string' ? op.insert : ''))
               .join('')
-          : 'mock'
+          : ''
       }
 
       setText(text: string) {


### PR DESCRIPTION
<!--
  Thanks for opening a pull request!
  Fill in the sections below to help reviewers understand your changes quickly.
  Delete any section that genuinely does not apply.
-->

#### 🔗 Related Issue

Closes #205 <!-- issue number -->
Type: Task<!-- What was the type of that issue? -->

___
#### 🐛 Description of Issue

<!--
  Briefly describe what the issue was that this PR solves.
  A reviewer should be able to understand the "why" without having to read the issue first.
-->

The Issue was that we used self-hosted instead of ubuntu-latest. Now that the repository is public we can use the GitHub-hosted runner instead. That should remove some overhead from the server. The GitHub-runner can be used unlimited on a public repository.

___
#### 🔧 What Has Changed

<!--
  Summarise the changes you made. Focus on WHAT changed, not HOW
  (the code speaks for itself). Bullet points work well here.
-->

- The files in `.github/workflows/` have all been updated to use GitHub-hosted runners
- `docs/AGENTS.md` was updated

___
#### 🧪 Testing

<!--
  Describe how this change has been tested.
  Check all that apply.
-->

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manually tested locally
- [x] No tests needed — explain why: Testing is done here in the repository. We'll have to look which runners is used to execute the current workflows.

___
#### Manual testing instructions:

To verify this issue is resolved, a reviewer should:
1. You can click on on the workflows that ran in this PR. 
2. In `Set up job` (the first one) you should be able to see which runner is used
3. The self-hosted runner has a runner name `sel2-5`. If you don't see this, it should normally be a GitHub-runner

___
#### ✅ Pre-merge Checklist

<!--
  Go through this checklist before marking the PR as ready for review.
  All boxes must be checked before merging (the branch protection rules will enforce most of these,
  but this checklist serves as a reminder and a paper trail).
-->

- [x] Linked to a related issue above
- [x] My code follows the project's code style (`npm run lint` passes)
- [x] All existing tests still pass (`npm test` passes)
- [x] New functionality is covered by tests (or wasn't needed: explained!)
- [x] I have reviewed my own diff before requesting review
- [x] At least 2 reviewers have been assigned (auto-assigned, but verify)

---

## 📸 Screenshots / Demo *(optional)*

<!-- If your change affects the UI, attach a before/after screenshot or a short screen recording. -->

