### PR TITLE
Add 404 page

### DIFF
--- a/backend/src/modules/taxonomies/taxonomies.schema.ts
+++ b/backend/src/modules/taxonomies/taxonomies.schema.ts
@@ -15,7 +15,7 @@ export const genrePaginationQuerySchema = z.object({
     limit: z.coerce.number().int().positive().max(100).default(20),
     search: z.string().optional(),
     lang: z.string().optional().default('nl'),
-    productionId: z.string().optional(),
+    productionId: z.string().uuid().optional(),
 })
 export const tagPaginationQuerySchema = genrePaginationQuerySchema
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import ProtectedAdminRoute, { AdminEntryRoute } from './pages/admin/ProtectedAdm
 import HomePage from './pages/public/HomePage'
 import ArchiveDetailPage from './pages/public/ArchiveDetailPage'
 import SearchPage from './pages/public/SearchPage'
+import NotFoundPage from './pages/public/NotFoundPage'
 
 // Admin pages (lazy loaded — not included in public bundle)
 const LoginPage = lazy(() => import('./pages/admin/LoginPage'))
@@ -48,6 +49,7 @@ function App() {
                         <Route path="/nl/blogs/:id" element={<BlogDetailPage />} />
                         <Route path="/en/blogs/:id" element={<BlogDetailPage />} />
 
+                        <Route path="*" element={<NotFoundPage />} />
                     </>
                 ) : null}
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,5 +1,15 @@
 const API_BASE = '/api/v1'
 
+export class ApiError extends Error {
+    status: number
+
+    constructor(status: number, message: string) {
+        super(message)
+        this.name = 'ApiError'
+        this.status = status
+    }
+}
+
 /**
  * API client for communicating with the Fastify backend.
  *
@@ -48,7 +58,7 @@ export async function apiFetch<T>(
                     ? errorPayload
                     : '') || `HTTP ${response.status}`
 
-        throw new Error(message)
+        throw new ApiError(response.status, message)
     }
 
     // Handle 204 No Content

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -221,6 +221,15 @@ const en: Messages = {
     editorSaveError: 'Failed to save editor.',
     editorDeleteError: 'Failed to delete editor.',
   },
+  notFound: {
+    titleTop: 'Four',
+    titleAccent: 'zero',
+    titleBottom: 'four',
+    joke: 'Coincidence? We think not. Our name is literally a 404 (vier-nul-vier).',
+    description: 'This page is not in the archive. Maybe it has not been digitised yet, maybe it never existed.\nEither way: head back home or dive into the archive.',
+    homeButton: 'back to home',
+    searchButton: 'search the archive',
+  },
   footer: {
     brandLogoAlt: 'VIERNULVIER logo',
     organizationName: 'VIERNULVIER Arts Centre vzw.',

--- a/frontend/src/i18n/locales/nl.ts
+++ b/frontend/src/i18n/locales/nl.ts
@@ -221,6 +221,15 @@ const nl: Messages = {
     editorSaveError: 'Editor opslaan mislukt.',
     editorDeleteError: 'Editor verwijderen mislukt.',
   },
+  notFound: {
+    titleTop: 'Vier',
+    titleAccent: 'nul',
+    titleBottom: 'vier',
+    joke: 'Toeval? We dachten het niet. Onze naam is letterlijk een 404.',
+    description: 'Deze pagina staat niet in het archief. Misschien is ze nog niet gedigitaliseerd, misschien bestond ze nooit.\nIn de tussentijd: terug naar de start of duik het archief in.',
+    homeButton: 'naar home',
+    searchButton: 'doorzoek archief',
+  },
   footer: {
     brandLogoAlt: 'VIERNULVIER logo',
     organizationName: 'Kunstencentrum VIERNULVIER vzw.',

--- a/frontend/src/i18n/types.ts
+++ b/frontend/src/i18n/types.ts
@@ -137,6 +137,15 @@ export type Messages = {
     previousImage: string
     nextImage: string
   }
+  notFound: {
+    titleTop: string
+    titleAccent: string
+    titleBottom: string
+    joke: string
+    description: string
+    homeButton: string
+    searchButton: string
+  }
   footer: {
     brandLogoAlt: string
     organizationName: string

--- a/frontend/src/pages/public/ArchiveDetailPage.tsx
+++ b/frontend/src/pages/public/ArchiveDetailPage.tsx
@@ -21,6 +21,8 @@ import { getSpaceById } from '../../api/spaces'
 import { getLocationById, type Location } from '../../api/locations'
 import { getPreviousStrippedPath } from '../../utils/navigationHistory'
 
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
 function ArchiveDetailPageContent() {
     const navigate = useNavigate()
     const messages = usePublicMessages()
@@ -37,6 +39,13 @@ function ArchiveDetailPageContent() {
     const [shareCopied, setShareCopied] = useState(false)
     const [loadError, setLoadError] = useState(false)
     const [notFound, setNotFound] = useState(false)
+    const [previousId, setPreviousId] = useState(id)
+
+    if (id !== previousId) {
+        setPreviousId(id)
+        setLoadError(false)
+        setNotFound(false)
+    }
 
     const handleGoBack = () => {
         const prev = getPreviousStrippedPath()
@@ -84,17 +93,10 @@ function ArchiveDetailPageContent() {
         window.setTimeout(() => setShareCopied(false), 1800)
     }
 
+    const idIsMalformed = typeof id === 'string' && !UUID_REGEX.test(id)
+
     useEffect(() => {
-        if (!id) return
-
-        setNotFound(false)
-        setLoadError(false)
-
-        const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
-        if (!UUID_REGEX.test(id)) {
-            setNotFound(true)
-            return
-        }
+        if (!id || idIsMalformed) return
 
         const fetchData = async () => {
             try {
@@ -166,7 +168,7 @@ function ArchiveDetailPageContent() {
         }
 
         fetchData()
-    }, [id])
+    }, [id, idIsMalformed])
 
     const title = localize(production?.title, locale)
     const superTitle = localize(production?.super_title, locale)
@@ -191,7 +193,7 @@ function ArchiveDetailPageContent() {
         .map((url) => getYouTubeEmbedUrl(url as string))
         .filter(Boolean)
 
-    if (notFound) {
+    if (notFound || idIsMalformed) {
         return <NotFoundContent />
     }
 

--- a/frontend/src/pages/public/ArchiveDetailPage.tsx
+++ b/frontend/src/pages/public/ArchiveDetailPage.tsx
@@ -6,6 +6,8 @@ import { getYouTubeEmbedUrl } from '../../utils/youtube'
 import PublicLayout from '../../components/public/PublicLayout'
 import PublicPillButton from '../../components/public/PublicPillButton'
 import { usePublicMessages } from '../../components/public/PublicMessagesContext'
+import { NotFoundContent } from './NotFoundPage'
+import { ApiError } from '../../api/client'
 import ArchiveDetailHero from '../../components/public/detail/PublicDetailHeroBanner'
 import ArchiveDetailEventsList from '../../components/public/detail/PublicDetailEventsList'
 import ArchiveDetailGallery from '../../components/public/detail/PublicDetailGallery'
@@ -34,6 +36,7 @@ function ArchiveDetailPageContent() {
     const [locationsByEvent, setLocationsByEvent] = useState<Record<string, Location>>({})
     const [shareCopied, setShareCopied] = useState(false)
     const [loadError, setLoadError] = useState(false)
+    const [notFound, setNotFound] = useState(false)
 
     const handleGoBack = () => {
         const prev = getPreviousStrippedPath()
@@ -83,6 +86,15 @@ function ArchiveDetailPageContent() {
 
     useEffect(() => {
         if (!id) return
+
+        setNotFound(false)
+        setLoadError(false)
+
+        const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+        if (!UUID_REGEX.test(id)) {
+            setNotFound(true)
+            return
+        }
 
         const fetchData = async () => {
             try {
@@ -144,8 +156,12 @@ function ArchiveDetailPageContent() {
                 })
                 setLocationsByEvent(locationMap)
 
-            } catch {
-                setLoadError(true)
+            } catch (error) {
+                if (error instanceof ApiError && (error.status === 404 || error.status === 400)) {
+                    setNotFound(true)
+                } else {
+                    setLoadError(true)
+                }
             }
         }
 
@@ -174,6 +190,10 @@ function ArchiveDetailPageContent() {
         .filter(Boolean)
         .map((url) => getYouTubeEmbedUrl(url as string))
         .filter(Boolean)
+
+    if (notFound) {
+        return <NotFoundContent />
+    }
 
     if (loadError) {
         return (

--- a/frontend/src/pages/public/NotFoundPage.tsx
+++ b/frontend/src/pages/public/NotFoundPage.tsx
@@ -1,0 +1,65 @@
+import { useNavigate } from 'react-router-dom'
+import { getActiveLocale, withLocalePath } from '../../i18n'
+import PublicLayout from '../../components/public/PublicLayout'
+import PublicPillButton from '../../components/public/PublicPillButton'
+import { usePublicMessages } from '../../components/public/PublicMessagesContext'
+
+export function NotFoundContent() {
+    const navigate = useNavigate()
+    const messages = usePublicMessages()
+    const locale = getActiveLocale(window.location.pathname)
+
+    const handleGoHome = () => {
+        navigate(withLocalePath('/', locale))
+    }
+
+    const handleGoSearch = () => {
+        navigate(withLocalePath('/zoeken', locale))
+    }
+
+    return (
+        <section className="relative overflow-hidden py-16 md:py-24">
+            <div className="pointer-events-none absolute -left-32 top-44 h-64 w-64 rounded-full bg-accent/30 blur-3xl" />
+            <div className="pointer-events-none absolute -right-24 -top-8 h-72 w-72 rounded-full bg-accent/40 blur-3xl" />
+
+            <div className="site-container relative flex max-w-3xl flex-col items-center text-center">
+                <h1 className="text-6xl font-regular leading-none text-text md:text-8xl">
+                    <span>{messages.notFound.titleTop}</span>{' '}
+                    <span className="text-accent">{messages.notFound.titleAccent}</span>{' '}
+                    <span className="text-text">{messages.notFound.titleBottom}</span>
+                </h1>
+
+                <p className="mt-6 text-lg font-semibold text-accent md:text-xl">
+                    {messages.notFound.joke}
+                </p>
+
+                <p className="mt-4 max-w-xl whitespace-pre-line text-base text-muted md:text-lg">
+                    {messages.notFound.description}
+                </p>
+
+                <div className="mt-10 flex flex-wrap items-center justify-center gap-3">
+                    <PublicPillButton
+                        label={messages.notFound.homeButton}
+                        variant="solid"
+                        onClick={handleGoHome}
+                    />
+                    <PublicPillButton
+                        label={messages.notFound.searchButton}
+                        variant="outline"
+                        onClick={handleGoSearch}
+                    />
+                </div>
+            </div>
+        </section>
+    )
+}
+
+function NotFoundPage() {
+    return (
+        <PublicLayout>
+            <NotFoundContent />
+        </PublicLayout>
+    )
+}
+
+export default NotFoundPage

--- a/frontend/src/test/pages/admin/ProtectedAdminRoute.test.tsx
+++ b/frontend/src/test/pages/admin/ProtectedAdminRoute.test.tsx
@@ -36,13 +36,7 @@ vi.mock('../../../pages/admin/CreateBlogPage', () => ({
 }))
 
 vi.mock('../../../i18n', async () => {
-  const actual = await vi.importActual<typeof import('../../../i18n')>('../../../i18n')
-  return {
-    ...actual,
-    getMessages: () => ({
-      common: { loading: 'Loading' },
-    }),
-  }
+  return await vi.importActual<typeof import('../../../i18n')>('../../../i18n')
 })
 
 function LoginPageProbe() {


### PR DESCRIPTION
#### 🔗 Related Issue

Closes #214

Type: feature

___
#### 🐛 Description of Issue

There was no proper 404 page on the public site. Bad URLs fell through to a blank screen, and a bad production id on `/archive/:id` showed the generic "Kon de productie niet laden" error. We wanted something that matches the rest of the site and ideally has a bit of personality.

___
#### 🔧 What Has Changed

- New `NotFoundPage` (public) with NL and EN copy, wrapped in `PublicLayout` so it gets the navbar, footer, locale toggle and theming for free.
- Catch-all route (`path="*"`) on the public host in `App.tsx`.
- `ApiError` class added to `api/client.ts` so callers can distinguish HTTP statuses (still extends `Error`, so existing generic catches keep working).
- `ArchiveDetailPage` now checks the `:id` against a UUID regex before fetching, and treats 400 / 404 from the production fetch as "page does not exist". `notFound` and `loadError` reset on every id change so navigation between productions doesn't get stuck on a stale 404.
- Backend: `productionId` in `taxonomies.schema.ts` now validates as `.uuid()`. Without this a malformed id reached Prisma and surfaced as a 500 (`P2007`) instead of a 400.

___
#### 🏗️ Design Choices

- **Reuse `PublicLayout` instead of a standalone shell:** the 404 should feel like the rest of the site. Having the nav, locale toggle and footer means people who land here aren't stuck.
- **Client-side UUID guard:** malformed ids are a clear "not found" signal, so there's no point hitting the API. Backend Zod still catches anything that slips past, and we treat 400 the same as 404 client-side.
- **Treat 400 as 404 for the production fetch:** from a visitor's perspective "the URL is bad" and "the row doesn't exist" are the same outcome. Other errors keep the existing `loadError` UI as a defensive fallback.
- **Export `NotFoundContent` separately from `NotFoundPage`:** `ArchiveDetailPage` is already inside `PublicLayout`, so it uses the bare content to avoid double-wrapping the layout.
- **The joke:** 404 in Dutch is "vier-nul-vier", which happens to be the brand name. Felt like a missed opportunity not to use it.

___
#### 🧪 Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manually tested locally
- [ ] No tests needed — explain why: ...

The only test change is in `ProtectedAdminRoute.test.tsx`. The new catch-all route causes `/dashboard` on the public host to render `PublicLayout`, which reads more keys than the previous partial `getMessages` stub provided. Switched the mock to forward to the real i18n module. Assertions are unchanged.

All 259 frontend tests pass. Type-check clean.

___
#### Manual testing instructions:

To verify this issue is resolved, a reviewer should:
1. Visit any nonexistent path (e.g. `/iets-dat-niet-bestaat`) and confirm the 404 page renders with the navbar, footer and locale toggle.
2. Visit `/archive/not-a-uuid` and confirm the 404 page renders without an API round trip.
3. Visit `/archive/00000000-0000-0000-0000-000000000000` (well-formed but missing) and confirm the 404 page renders.
4. From the 404 page, toggle the locale and confirm copy switches between Dutch and English.
5. Click "naar home" to verify it goes home in the current locale; click "doorzoek archief" to verify it goes to `/zoeken`.
6. Navigate from a bad id to a real production id (or vice versa) without a full page reload and confirm the view updates correctly.

___
#### ✅ Pre-merge Checklist

- [x] Linked to a related issue above
- [x] My code follows the project's code style (`npm run lint` passes)
- [x] All existing tests still pass (`npm test` passes)
- [x] New functionality is covered by tests (or wasn't needed: explained!)
- [x] I have reviewed my own diff before requesting review
- [x] At least 2 reviewers have been assigned (auto-assigned, but verify)

---

## 📸 Screenshots / Demo *(optional)*

<img width="1509" height="860" alt="Screenshot 2026-05-02 at 18 12 28" src="https://github.com/user-attachments/assets/f459ebdb-719d-4fc1-91fe-f15bdaecafdb" />