### PR TITLE
Gave visual clue when hovering over "Year" and "Genre" buttons + Location search fix

### DIFF
--- a/frontend/src/components/public/PublicHeroSearch.tsx
+++ b/frontend/src/components/public/PublicHeroSearch.tsx
@@ -58,7 +58,7 @@ function SelectPill({
                 value={value}
                 onChange={(event) => onChange(event.target.value)}
                 disabled={disabled}
-                className="h-12 w-full appearance-none rounded-md bg-background pl-4 pr-12 text-sm font-semibold text-foreground disabled:cursor-not-allowed disabled:opacity-70"
+                className="h-12 w-full appearance-none rounded-md bg-background pl-4 pr-12 text-sm font-semibold text-foreground disabled:cursor-not-allowed disabled:opacity-70 cursor-pointer"
             >
                 <option value="">{label}</option>
                 {options.map((option) => (

--- a/frontend/src/pages/public/SearchPage.tsx
+++ b/frontend/src/pages/public/SearchPage.tsx
@@ -988,24 +988,24 @@ function FilterPanel({ className, onAfterChange, showSearch = true, shareLabel, 
             <div className="mt-6 border-t border-border pt-5 pb-5">
                 <h3 className="text-sm font-semibold uppercase tracking-widest text-foreground">{s.locationLabel}</h3>
                 <div className="mt-4 space-y-3 text-sm text-text-accent">
-                    <div className="flex items-center gap-2">
-                        <input
-                            type="text"
-                            value={locationInput}
-                            onChange={(event) => setLocationInput(event.target.value)}
-                            onFocus={() => setIsLocationSuggestionsOpen(true)}
-                            onBlur={() => {
-                                window.setTimeout(() => {
-                                    setIsLocationSuggestionsOpen(false)
-                                }, 120)
-                            }}
-                            onKeyDown={(event) => {
-                                if (event.key === 'Enter') {
-                                    event.preventDefault()
-                                    handleAddLocation()
-                                }
-                            }}
-                            placeholder={s.locationSearchPlaceholder}
+                        <div className="flex items-center gap-2">
+                            <input
+                                type="text"
+                                value={locationInput}
+                                onChange={(event) => setLocationInput(event.target.value)}
+                                onFocus={() => setIsLocationSuggestionsOpen(true)}
+                                onBlur={() => {
+                                    window.setTimeout(() => {
+                                        setIsLocationSuggestionsOpen(false)
+                                    }, 120)
+                                }}
+                                onKeyDown={(event) => {
+                                    if (event.key === 'Enter') {
+                                        event.preventDefault()
+                                        handleAddLocation()
+                                    }
+                                }}
+                                placeholder={s.locationSearchPlaceholder}
                             className="h-10 w-full rounded-full border border-border bg-surface px-4 text-sm text-foreground"
                         />
                         <button
@@ -1038,7 +1038,10 @@ function FilterPanel({ className, onAfterChange, showSearch = true, shareLabel, 
                                 <button
                                     key={value}
                                     type="button"
-                                    onClick={() => handleLocationChange(value)}
+                                    onMouseDown={(e) => {
+                                        e.preventDefault()
+                                        handleLocationChange(value)
+                                    }}
                                     className="inline-flex items-center gap-1.5 rounded-full bg-accent/15 px-3 py-1 text-xs text-accent"
                                 >
                                     <span>{getLocationLabel(value)}</span>


### PR DESCRIPTION

#### 🔗 Related Issue

Closes #182 
Type: <!-- What was the type of that issue? -->

___
#### 🐛 Description of Issue

The Issue was both the search bar and search button had a visual clue when hovering over it, the year and genre (and location) button didnt. 
And the Location search on the actual search screen didnt work.

___
#### 🔧 What Has Changed


- changed the SelectPill to show visual clue
- changed the location search to select location before closing the dropdown with locations

___
#### 🏗️ Design Choices

<!--
  Explain the non-obvious decisions you made and why you made them.
  Were there alternatives you considered and rejected? Mention them here
  so reviewers understand the tradeoffs and do not suggest paths you already explored.
-->

- **Why X instead of Y:** ...
- **Trade-offs accepted:** ...

#### Manual testing instructions:

To verify this issue is resolved, a reviewer should:
1. check if hovering the genre and year button changes their cursor.
2. check if the location search works to their liking
3. ...

___
#### ✅ Pre-merge Checklist

<!--
  Go through this checklist before marking the PR as ready for review.
  All boxes must be checked before merging (the branch protection rules will enforce most of these,
  but this checklist serves as a reminder and a paper trail).
-->

- [ ] Linked to a related issue above
- [ ] My code follows the project's code style (`npm run lint` passes)
- [ ] All existing tests still pass (`npm test` passes)
- [ ] New functionality is covered by tests (or wasn't needed: explained!)
- [ ] I have reviewed my own diff before requesting review
- [ ] At least 2 reviewers have been assigned (auto-assigned, but verify)

---

## 📸 Screenshots / Demo *(optional)*

<!-- If your change affects the UI, attach a before/after screenshot or a short screen recording. -->

