### PR TITLE
made detailGallery preload images

### DIFF
--- a/frontend/src/components/public/detail/PublicDetailGallery.tsx
+++ b/frontend/src/components/public/detail/PublicDetailGallery.tsx
@@ -15,6 +15,11 @@ function ArchiveDetailGallery({ images }: ArchiveDetailGalleryProps) {
 
     return (
         <div className="relative w-full">
+            <div className="hidden">
+                {images.map((src, i) => src && i !== current && (
+                    <img key={i} src={src} alt="" />
+                ))}
+            </div>
             <div className="w-full rounded-xl overflow-hidden">
                 {images[current] && (
                     <img


### PR DESCRIPTION
<!--
  Thanks for opening a pull request!
  Fill in the sections below to help reviewers understand your changes quickly.
  Delete any section that genuinely does not apply.
-->

#### 🔗 Related Issue

Closes #226 <!-- issue number -->
Type: Performance Issue <!-- What was the type of that issue? -->

___
#### 🐛 Description of Issue

<!--
  Briefly describe what the issue was that this PR solves.
  A reviewer should be able to understand the "why" without having to read the issue first.
-->

The Issue was that currently the production detail page is only rendering the current image in the shown media. It doesn't preload the next images which causes you to have to see a delay sometimes when you go to the next image.

___
#### 🔧 What Has Changed

<!--
  Summarise the changes you made. Focus on WHAT changed, not HOW
  (the code speaks for itself). Bullet points work well here.
-->

- PublicDetailGallery fetches and caches all the images when the gallery is mounted

___
#### 🧪 Testing

<!--
  Describe how this change has been tested.
  Check all that apply.
-->

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manually tested locally
- [x] No tests needed — explain why: This is hidden, it doesn't affect any observable behavior.

___
#### Manual testing instructions:

To verify this issue is resolved, a reviewer should:
1. do `npm run dev` in both frontend and backend
2. Go to a production detail page that includes multiple images in the gallery
3. Check that there isn't any delay because the images weren't cached yet.

___
#### ✅ Pre-merge Checklist

<!--
  Go through this checklist before marking the PR as ready for review.
  All boxes must be checked before merging (the branch protection rules will enforce most of these,
  but this checklist serves as a reminder and a paper trail).
-->

- [x] Linked to a related issue above
- [x] My code follows the project's code style (`npm run lint` passes)
- [x] All existing tests still pass (`npm test` passes)
- [x] New functionality is covered by tests (or wasn't needed: explained!)
- [x] I have reviewed my own diff before requesting review
- [x] At least 2 reviewers have been assigned (auto-assigned, but verify)

---

## 📸 Screenshots / Demo *(optional)*

<!-- If your change affects the UI, attach a before/after screenshot or a short screen recording. -->

