### PR TITLE
use set and array to deduplicate videos

### DIFF
--- a/frontend/src/pages/public/ArchiveDetailPage.tsx
+++ b/frontend/src/pages/public/ArchiveDetailPage.tsx
@@ -161,8 +161,6 @@ function ArchiveDetailPageContent() {
     const quote = localize(production?.quote, locale)
     const quoteSource = localize(production?.quote_source, locale)
     const info = localize(production?.info, locale)
-    const video1 = localize(production?.video_1, locale)
-    const video2 = localize(production?.video_2, locale)
     const hasSidebar = Boolean(info) || genres.length > 0 || tags.length > 0
     const shareLabel = messages.search.shareLabel
     const shareCopiedLabel = messages.search.shareCopiedLabel
@@ -170,10 +168,18 @@ function ArchiveDetailPageContent() {
     const FALLBACK_IMAGE = '/fallback-hero.svg'
     const heroImage = imageUrl ?? FALLBACK_IMAGE
 
-    const videos = [video1, video2]
-        .filter(Boolean)
-        .map((url) => getYouTubeEmbedUrl(url as string))
-        .filter(Boolean)
+    const videos = Array.from(
+        new Set(
+            [
+                localize(production?.video_1, locale),
+                localize(production?.video_2, locale),
+            ]
+                .filter((url): url is string => Boolean(url))
+                .map(getYouTubeEmbedUrl)
+                .filter((url): url is string => Boolean(url))
+        )
+    )
+        
 
     if (loadError) {
         return (

--- a/frontend/src/test/pages/public/ArchiveDetailPage.test.tsx
+++ b/frontend/src/test/pages/public/ArchiveDetailPage.test.tsx
@@ -451,6 +451,28 @@ describe('ArchiveDetailPage', () => {
         })
     })
 
+    it('renders a single video when the urls are the same', async () => {
+        getProductionByIdMock.mockResolvedValue({
+            data: { 
+                ...baseProduction, 
+                video_1: { nl: 'https://www.youtube.com/watch?v=abc123' }, 
+                video_2: { nl: 'https://www.youtube.com/watch?v=abc123' }
+            },
+        })
+
+        renderPage()
+
+        await waitFor(() => {
+            const iframe = document.querySelector('iframe')
+            expect(iframe).toHaveAttribute('src', 'https://www.youtube.com/embed/abc123')
+            expect(iframe).toHaveAttribute('title', 'Video 1')
+            expect(iframe).not.toHaveAttribute('title', 'Video 2')
+            // single video gets the wide container
+            const container = iframe?.closest('.max-w-3xl')
+            expect(container).toBeInTheDocument()
+        })
+    })
+
     it('does not render any iframes when there are no valid video urls', async () => {
         getProductionByIdMock.mockResolvedValue({
             data: { ...baseProduction, video_1: null, video_2: null },


### PR DESCRIPTION
<!--
  Thanks for opening a pull request!
  Fill in the sections below to help reviewers understand your changes quickly.
  Delete any section that genuinely does not apply.
-->

#### 🔗 Related Issue

Closes #238 <!-- issue number -->
Type: Bug <!-- What was the type of that issue? -->

___
#### 🐛 Description of Issue

<!--
  Briefly describe what the issue was that this PR solves.
  A reviewer should be able to understand the "why" without having to read the issue first.
-->

The Issue was that in certain productions that contain both a video_1 and video_2, those 2 are the same video using the same url. This should be checked so we don't show the same video twice right next to each other.

___
#### 🔧 What Has Changed

<!--
  Summarise the changes you made. Focus on WHAT changed, not HOW
  (the code speaks for itself). Bullet points work well here.
-->

- Ensured there are no duplicate urls in the videos

___
#### 🏗️ Design Choices

<!--
  Explain the non-obvious decisions you made and why you made them.
  Were there alternatives you considered and rejected? Mention them here
  so reviewers understand the tradeoffs and do not suggest paths you already explored.
-->

- I transformed the array of 2 videos into a set and back into an array. This was the easiest fix I could think of.

___
#### 🧪 Testing

<!--
  Describe how this change has been tested.
  Check all that apply.
-->

- [ ] Unit tests added / updated
- [x] Integration tests added / updated
- [x] Manually tested locally
- [ ] No tests needed — explain why: ...

___
#### Manual testing instructions:

To verify this issue is resolved, a reviewer should:
1. Run `npm run dev` in both frontend and backend
2. Go to a production that has both a `video_1` and `video_2` (some examples are "Jolly", "Past Lives", "Perfect Days", check in backend if they actually do contain both)
3. Look at the production page and make sure there is only 1 video shown.

___
#### ✅ Pre-merge Checklist

<!--
  Go through this checklist before marking the PR as ready for review.
  All boxes must be checked before merging (the branch protection rules will enforce most of these,
  but this checklist serves as a reminder and a paper trail).
-->

- [x] Linked to a related issue above
- [x] My code follows the project's code style (`npm run lint` passes)
- [x] All existing tests still pass (`npm test` passes)
- [x] New functionality is covered by tests (or wasn't needed: explained!)
- [x] I have reviewed my own diff before requesting review
- [x] At least 2 reviewers have been assigned (auto-assigned, but verify)

---

## 📸 Screenshots / Demo *(optional)*

<!-- If your change affects the UI, attach a before/after screenshot or a short screen recording. -->

