### PR TITLE
fix match only works on string

### DIFF
--- a/backend/src/scraper/crops_downloader.ts
+++ b/backend/src/scraper/crops_downloader.ts
@@ -23,7 +23,7 @@ async function download_crop(crop: crop) {
         let extension = 'webp'
         if (response.headers) {
             const contentType = response.headers['content-type'];
-            if (contentType !== undefined && contentType != null) {
+            if (contentType !== undefined && contentType != null && typeof contentType === 'string') {
                 const match = contentType!.match(/\/([a-zA-Z0-9]+)/);
                 if (match) {
                     extension = match[1];


### PR DESCRIPTION

#### 🔗 Related Issue

Closes #<!-- issue number -->
Type: Bug
___
#### 🐛 Description of Issue

The Issue was the match inside of crops_downloader needed an extra string check because the typeof contentType could be something else than a string

___
#### 🔧 What Has Changed

<!--
  Summarise the changes you made. Focus on WHAT changed, not HOW
  (the code speaks for itself). Bullet points work well here.
-->

- added extra string check in if
- ...

___
#### 🏗️ Design Choices

<!--
  Explain the non-obvious decisions you made and why you made them.
  Were there alternatives you considered and rejected? Mention them here
  so reviewers understand the tradeoffs and do not suggest paths you already explored.
-->

- **Why X instead of Y:** ...
- **Trade-offs accepted:** ...

___
#### 🧪 Testing

<!--
  Describe how this change has been tested.
  Check all that apply.
-->

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manually tested locally
- [ ] No tests needed — explain why: ...

___
#### Manual testing instructions:

To verify this issue is resolved, a reviewer should:
1. see if the crops still download correctly
2. ...
3. ...

___
#### ✅ Pre-merge Checklist

<!--
  Go through this checklist before marking the PR as ready for review.
  All boxes must be checked before merging (the branch protection rules will enforce most of these,
  but this checklist serves as a reminder and a paper trail).
-->

- [ ] Linked to a related issue above
- [ ] My code follows the project's code style (`npm run lint` passes)
- [ ] All existing tests still pass (`npm test` passes)
- [ ] New functionality is covered by tests (or wasn't needed: explained!)
- [ ] I have reviewed my own diff before requesting review
- [ ] At least 2 reviewers have been assigned (auto-assigned, but verify)

---

## 📸 Screenshots / Demo *(optional)*

<!-- If your change affects the UI, attach a before/after screenshot or a short screen recording. -->

