### PR TITLE
refactor: route remaining public pages and PublicCarousel through usePublicMessages

### DIFF
--- a/frontend/src/components/public/PublicCarousel.tsx
+++ b/frontend/src/components/public/PublicCarousel.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { apiFetch } from '../../api/client'
-import { getActiveLocale, getMessages, withLocalePath } from '../../i18n'
-import type { Locale } from '../../i18n/types'
+import { getActiveLocale, withLocalePath } from '../../i18n'
+import type { Locale, Messages } from '../../i18n/types'
+import { usePublicMessages } from './PublicMessagesContext'
 import SearchResultCard, { type SearchResultItem } from './search/SearchResultCard'
 import SectionTitle from './SectionTitle'
 
@@ -77,10 +78,9 @@ function toPlainText(value: string): string {
     return trimmed.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim()
 }
 
-function getGenreLabel(value: string, locale: Locale): string {
-    const labels = getMessages(locale).search.genres
+function getGenreLabel(value: string, genreLabels: Messages['search']['genres']): string {
     const index = CANONICAL_GENRE_VALUES.indexOf(value as (typeof CANONICAL_GENRE_VALUES)[number])
-    return index >= 0 ? labels[index] ?? value : value
+    return index >= 0 ? genreLabels[index] ?? value : value
 }
 
 function formatDate(value: Date | string, locale: Locale): string {
@@ -93,21 +93,20 @@ function formatDate(value: Date | string, locale: Locale): string {
     }).format(date)
 }
 
-function mapProductionToCarouselItem(item: ProductionApiItem, locale: Locale): SearchResultItem {
-    const messages = getMessages(locale)
-    const title = getLocalizedText(item.title, locale) || messages.search.fallbackUntitled
+function mapProductionToCarouselItem(item: ProductionApiItem, locale: Locale, searchMessages: Messages['search']): SearchResultItem {
+    const title = getLocalizedText(item.title, locale) || searchMessages.fallbackUntitled
     const excerptRaw =
         getLocalizedText(item.description_short, locale) ||
         getLocalizedText(item.description, locale) ||
         getLocalizedText(item.teaser, locale) ||
         title
     const excerpt = toPlainText(excerptRaw) || title
-    
+
     const normalizedLocation = (item.attendance_mode ?? '').trim().toLowerCase()
     const hasConcreteAttendanceMode = normalizedLocation.length > 0 && normalizedLocation !== 'offline' && normalizedLocation !== 'online'
-    const fallbackVenue = messages.search.fallbackVenue
+    const fallbackVenue = searchMessages.fallbackVenue
     const venue = hasConcreteAttendanceMode ? normalizedLocation : fallbackVenue
-    const fallbackTag = messages.search.fallbackTag
+    const fallbackTag = searchMessages.fallbackTag
 
     return {
         id: item.id,
@@ -218,7 +217,7 @@ function useProductionEventDetails(items: ProductionApiItem[], locale: Locale, r
     return details
 }
 
-function useProductionTaxonomies(items: ProductionApiItem[], locale: Locale) {
+function useProductionTaxonomies(items: ProductionApiItem[], locale: Locale, genreLabels: Messages['search']['genres']) {
     const [taxonomies, setTaxonomies] = useState<Record<string, string>>({})
     useEffect(() => {
         const fetchTaxonomies = async () => {
@@ -232,7 +231,7 @@ function useProductionTaxonomies(items: ProductionApiItem[], locale: Locale) {
                             const res = await apiFetch<{ data: Array<{ slug: LocalizedText, name: LocalizedText }> }>(gPath)
                             if (res.data?.[0]) {
                                 const slug = getLocalizedText(res.data[0].slug, locale) || getLocalizedText(res.data[0].name, locale)
-                                if (slug) return { id: item.id, label: getGenreLabel(slug.toLowerCase(), locale) }
+                                if (slug) return { id: item.id, label: getGenreLabel(slug.toLowerCase(), genreLabels) }
                             }
                         }
                         const tPath = getRelativePath(item.links?.tags)
@@ -240,7 +239,7 @@ function useProductionTaxonomies(items: ProductionApiItem[], locale: Locale) {
                             const res = await apiFetch<{ data: Array<{ slug: LocalizedText, name: LocalizedText }> }>(tPath)
                             if (res.data?.[0]) {
                                 const slug = getLocalizedText(res.data[0].slug, locale) || getLocalizedText(res.data[0].name, locale)
-                                if (slug) return { id: item.id, label: getGenreLabel(slug.toLowerCase(), locale) }
+                                if (slug) return { id: item.id, label: getGenreLabel(slug.toLowerCase(), genreLabels) }
                             }
                         }
                         return { id: item.id, label: '' }
@@ -252,13 +251,13 @@ function useProductionTaxonomies(items: ProductionApiItem[], locale: Locale) {
             setTaxonomies(prev => ({ ...prev, ...newT }))
         }
         fetchTaxonomies()
-    }, [items, locale])
+    }, [items, locale, genreLabels])
     return taxonomies
 }
 
 function PublicCarousel() {
     const locale = getActiveLocale(window.location.pathname)
-    const messages = getMessages(locale)
+    const messages = usePublicMessages()
     const [apiRawItems, setApiRawItems] = useState<ProductionApiItem[]>([])
     const [isLoading, setIsLoading] = useState(true)
     const [error, setError] = useState<string | null>(null)
@@ -272,7 +271,7 @@ function PublicCarousel() {
 
     const fetchedImages = useProductionImages(apiRawItems)
     const fetchedDetails = useProductionEventDetails(apiRawItems, locale, mode === 'on-this-day' ? referenceDate : undefined)
-    const fetchedTaxonomies = useProductionTaxonomies(apiRawItems, locale)
+    const fetchedTaxonomies = useProductionTaxonomies(apiRawItems, locale, messages.search.genres)
 
     // Fix: Force scroll to start when new items arrive
     useEffect(() => {
@@ -303,7 +302,7 @@ function PublicCarousel() {
 
     const carouselItems = useMemo(() => {
         const mapped = apiRawItems.map((item): SearchResultItem => {
-            const base = mapProductionToCarouselItem(item, locale)
+            const base = mapProductionToCarouselItem(item, locale, messages.search)
             const detail = fetchedDetails[item.id]
             const taxonomy = fetchedTaxonomies[item.id]
             return {
@@ -315,7 +314,7 @@ function PublicCarousel() {
             }
         })
         return prioritizeItemsWithImage(mapped)
-    }, [apiRawItems, fetchedImages, fetchedDetails, fetchedTaxonomies, locale])
+    }, [apiRawItems, fetchedImages, fetchedDetails, fetchedTaxonomies, locale, messages.search])
 
     const scroll = (d: -1 | 1) => scrollerRef.current?.scrollBy({ left: d * scrollerRef.current.clientWidth * 0.9, behavior: 'smooth' })
     const heading = mode === 'fallback-recent' ? messages.home.onThisDayFallbackHeading : messages.home.onThisDayHeading

--- a/frontend/src/pages/public/BlogDetailPage.tsx
+++ b/frontend/src/pages/public/BlogDetailPage.tsx
@@ -4,6 +4,7 @@ import Quill from 'quill'
 import 'quill/dist/quill.snow.css'
 import { api } from '../../api/client'
 import PublicLayout from '../../components/public/PublicLayout'
+import { usePublicMessages } from '../../components/public/PublicMessagesContext'
 import { getActiveLocale, withLocalePath } from '../../i18n'
 import ProductionCard from '../../components/blogs/ProductionCard'
 import {
@@ -15,7 +16,6 @@ import {
     type BlogLinkedProduction,
     type ProductionDetailResponse,
 } from './blogDetailPage.formatters'
-import { getMessages } from '../../i18n'
 
 /*
 This page shows the content of a blog in both english and dutch (/en or /nl). You can also click on the productions that are related to this blog
@@ -51,10 +51,10 @@ function QuillReadOnly({ content }: { content: unknown }) {
     return <div ref={containerRef} className="overflow-hidden rounded-xl border border-border bg-surface" />
 }
 
-function BlogDetailPage() {
+function BlogDetailPageContent() {
     const { id } = useParams<{ id: string }>()
     const locale = getActiveLocale(window.location.pathname)
-    const message = getMessages(locale)
+    const message = usePublicMessages()
     const [blog, setBlog] = useState<BlogDetails | null>(null)
     const [productions, setProductions] = useState<BlogLinkedProduction[]>([])
     const [isLoading, setIsLoading] = useState(true)
@@ -118,52 +118,58 @@ function BlogDetailPage() {
     }, [id, locale])
 
     return (
+        <section className="site-container py-12">
+            <div className="mb-8 flex items-center justify-between gap-4">
+                <Link
+                    to={withLocalePath('/', locale)}
+                    className="text-sm font-medium text-[var(--color-accent)] transition hover:opacity-80"
+                >
+                    {message.blogs.detailPageBack}
+                </Link>
+            </div>
+
+            {isLoading ? <p className="text-center text-muted">{message.blogs.loadingBlog}</p> : null}
+            {error ? <p className="text-center text-red-500">{error}</p> : null}
+
+            {!isLoading && !error && blog ? (
+                <article className="mx-auto max-w-4xl">
+                    <h1 className="mb-6 text-4xl font-semibold leading-tight text-foreground [overflow-wrap:anywhere]">
+                        {getLocalizedTitle(blog.title, locale) || message.blogs.untitledBlog}
+                    </h1>
+                    <QuillReadOnly content={getLocalizedContent(blog.content, locale)} />
+
+                    {isLoadingProductions || productions.length > 0 ? (
+                        <section className="mt-10">
+                            <h2 className="mb-4 text-2xl font-semibold text-foreground">
+                                {message.blogs.relatedProductions}
+                            </h2>
+
+                            {isLoadingProductions ? <p className="text-sm text-muted">{message.blogs.loadingProductions}</p> : null}
+
+                            {!isLoadingProductions && productions.length > 0 ? (
+                                <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                                    {productions.map((production) => (
+                                        <ProductionCard
+                                            key={production.id}
+                                            production={production}
+                                            locale={locale}
+                                            href={withLocalePath(`/archive/${production.id}`, locale)}
+                                        />
+                                    ))}
+                                </div>
+                            ) : null}
+                        </section>
+                    ) : null}
+                </article>
+            ) : null}
+        </section>
+    )
+}
+
+function BlogDetailPage() {
+    return (
         <PublicLayout>
-            <section className="site-container py-12">
-                <div className="mb-8 flex items-center justify-between gap-4">
-                    <Link
-                        to={withLocalePath('/', locale)}
-                        className="text-sm font-medium text-[var(--color-accent)] transition hover:opacity-80"
-                    >
-                        {message.blogs.detailPageBack}
-                    </Link>
-                </div>
-
-                {isLoading ? <p className="text-center text-muted">{message.blogs.loadingBlog}</p> : null}
-                {error ? <p className="text-center text-red-500">{error}</p> : null}
-
-                {!isLoading && !error && blog ? (
-                    <article className="mx-auto max-w-4xl">
-                        <h1 className="mb-6 text-4xl font-semibold leading-tight text-foreground [overflow-wrap:anywhere]">
-                            {getLocalizedTitle(blog.title, locale) || message.blogs.untitledBlog}
-                        </h1>
-                        <QuillReadOnly content={getLocalizedContent(blog.content, locale)} />
-
-                        {isLoadingProductions || productions.length > 0 ? (
-                            <section className="mt-10">
-                                <h2 className="mb-4 text-2xl font-semibold text-foreground">
-                                    {message.blogs.relatedProductions}
-                                </h2>
-
-                                {isLoadingProductions ? <p className="text-sm text-muted">{message.blogs.loadingProductions}</p> : null}
-
-                                {!isLoadingProductions && productions.length > 0 ? (
-                                    <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-                                        {productions.map((production) => (
-                                            <ProductionCard
-                                                key={production.id}
-                                                production={production}
-                                                locale={locale}
-                                                href={withLocalePath(`/archive/${production.id}`, locale)}
-                                            />
-                                        ))}
-                                    </div>
-                                ) : null}
-                            </section>
-                        ) : null}
-                    </article>
-                ) : null}
-            </section>
+            <BlogDetailPageContent />
         </PublicLayout>
     )
 }

--- a/frontend/src/pages/public/SearchPage.tsx
+++ b/frontend/src/pages/public/SearchPage.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent, type PointerEvent as ReactPointerEvent } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
-import { getActiveLocale, getMessages, withLocalePath } from '../../i18n'
-import type { Locale } from '../../i18n/types'
+import { getActiveLocale, withLocalePath } from '../../i18n'
+import type { Locale, Messages } from '../../i18n/types'
 import { apiFetch } from '../../api/client'
 import { getLocalizedContent, getLocalizedTitle, normalizeContent } from './blogDetailPage.formatters'
 import PublicLayout from '../../components/public/PublicLayout'
+import { usePublicMessages } from '../../components/public/PublicMessagesContext'
 import SearchPagination from '../../components/public/search/SearchPagination'
 import SearchResultCard, { type SearchResultItem } from '../../components/public/search/SearchResultCard'
 
@@ -263,8 +264,7 @@ function normalizeGenreValue(value: string): string {
     return GENRE_ALIASES[normalized] ?? normalized
 }
 
-function mapProductionToSearchEntry(item: ProductionApiItem, locale: Locale, preferredGenre?: string): SearchEntry {
-    const searchMessages = getMessages(locale).search
+function mapProductionToSearchEntry(item: ProductionApiItem, locale: Locale, searchMessages: Messages['search'], preferredGenre?: string): SearchEntry {
     const title = getLocalizedText(item.title, locale) || searchMessages.fallbackUntitled
     const excerptRaw =
         getLocalizedText(item.description_short, locale) ||
@@ -312,7 +312,7 @@ function mapProductionToSearchEntry(item: ProductionApiItem, locale: Locale, pre
 
     return {
         id: item.id,
-        tag: normalizedGenre ? getGenreLabel(normalizedGenre, locale) : searchMessages.fallbackTag,
+        tag: normalizedGenre ? getGenreLabel(normalizedGenre, searchMessages.genres) : searchMessages.fallbackTag,
         date: formatDate(item.created_at, locale),
         title,
         excerpt,
@@ -374,8 +374,7 @@ function getBlogExcerpt(content: unknown, locale: Locale, fallback: string): str
     return toPlainText(localizedContent) || fallback
 }
 
-function mapBlogToSearchEntry(item: BlogApiItem, locale: Locale): SearchEntry {
-    const searchMessages = getMessages(locale).search
+function mapBlogToSearchEntry(item: BlogApiItem, locale: Locale, searchMessages: Messages['search']): SearchEntry {
     const title = getLocalizedTitle(item.title, locale) || searchMessages.fallbackUntitled
     const date = item.createdAt ? formatDate(item.createdAt, locale) : '-'
     const year = item.createdAt ? new Date(item.createdAt).getFullYear() : MIN_PERIOD_YEAR
@@ -685,10 +684,9 @@ function parseSelectedLocations(searchParams: URLSearchParams): string[] {
     return legacyLocation ? [LOCATION_ALIASES[legacyLocation] ?? legacyLocation] : []
 }
 
-function getGenreLabel(value: string, locale: Locale): string {
-    const labels = getMessages(locale).search.genres
+function getGenreLabel(value: string, genreLabels: Messages['search']['genres']): string {
     const index = CANONICAL_GENRE_VALUES.indexOf(value as (typeof CANONICAL_GENRE_VALUES)[number])
-    return index >= 0 ? labels[index] ?? value : value
+    return index >= 0 ? genreLabels[index] ?? value : value
 }
 
 function getLocationLabel(value: string): string {
@@ -724,7 +722,7 @@ function FilterPanel({ className, onAfterChange, showSearch = true, shareLabel, 
     const [searchParams] = useSearchParams()
     const navigate = useNavigate()
     const locale = getActiveLocale(window.location.pathname)
-    const { search: s } = getMessages(locale)
+    const { search: s } = usePublicMessages()
 
     const filterState = useMemo(() => parseSearchFilterState(searchParams), [searchParams])
     const query = filterState.query
@@ -1080,7 +1078,7 @@ function MobileSearchForm({ className = 'mb-5 md:hidden' }: { className?: string
     const [searchParams] = useSearchParams()
     const navigate = useNavigate()
     const locale = getActiveLocale(window.location.pathname)
-    const { search: s } = getMessages(locale)
+    const { search: s } = usePublicMessages()
     const filterState = useMemo(() => parseSearchFilterState(searchParams), [searchParams])
     const query = filterState.query
     const [searchInput, setSearchInput] = useState(query)
@@ -1144,11 +1142,12 @@ function MobileSearchForm({ className = 'mb-5 md:hidden' }: { className?: string
     )
 }
 
-function SearchPage() {
+function SearchPageContent() {
     const [searchParams] = useSearchParams()
     const navigate = useNavigate()
     const locale = getActiveLocale(window.location.pathname)
-    const m = getMessages(locale)
+    const m = usePublicMessages()
+    const searchMessages = m.search
     const [isMobileFiltersOpen, setIsMobileFiltersOpen] = useState(false)
     const [shareCopied, setShareCopied] = useState(false)
     const [apiEntries, setApiEntries] = useState<SearchEntry[]>([])
@@ -1201,7 +1200,7 @@ function SearchPage() {
                         `/archive/blogs?${params.toString()}`,
                         { signal: abortController.signal }
                     )
-                    const mappedEntries = response.data.map((item) => mapBlogToSearchEntry(item, locale))
+                    const mappedEntries = response.data.map((item) => mapBlogToSearchEntry(item, locale, searchMessages))
                     setApiEntries(mappedEntries)
                     setTotalResults(response.meta?.total ?? mappedEntries.length)
                     setTotalPages(Math.max(1, response.meta?.totalPages ?? 1))
@@ -1237,6 +1236,7 @@ function SearchPage() {
                                     updatedAt: item.created_at ?? '',
                                 },
                                 locale,
+                                searchMessages,
                             )
                         }
                         return mapProductionToSearchEntry(
@@ -1255,6 +1255,7 @@ function SearchPage() {
                                 created_at: item.created_at ?? '',
                             },
                             locale,
+                            searchMessages,
                             preferredGenre,
                         )
                     })
@@ -1291,7 +1292,7 @@ function SearchPage() {
                     )
 
                     const preferredGenre = selectedGenres.length === 1 ? selectedGenres[0] : undefined
-                    const mappedEntries = response.data.map((item) => mapProductionToSearchEntry(item, locale, preferredGenre))
+                    const mappedEntries = response.data.map((item) => mapProductionToSearchEntry(item, locale, searchMessages, preferredGenre))
                     setApiRawItems(response.data)
                     setApiEntries(mappedEntries)
                     setTotalResults(response.meta?.total ?? mappedEntries.length)
@@ -1319,7 +1320,7 @@ function SearchPage() {
         return () => {
             abortController.abort()
         }
-    }, [query, locale, selectedGenres, selectedLocations, safeFromYear, safeToYear, sort, page, pageSize, tab])
+    }, [query, locale, selectedGenres, selectedLocations, safeFromYear, safeToYear, sort, page, pageSize, tab, searchMessages])
 
     const navigateWithFilters = (filters: SearchFilterOverrides) => {
         const params = buildSearchParams(filters)
@@ -1462,7 +1463,7 @@ function SearchPage() {
     const filterChips: Array<{ key: string; label: string; onRemove: () => void }> = [
         ...selectedGenres.map((value) => ({
             key: `genre-${value}`,
-            label: getGenreLabel(value, locale),
+            label: getGenreLabel(value, searchMessages.genres),
             onRemove: () => handleRemoveGenreChip(value),
         })),
         ...selectedLocations.map((value) => ({
@@ -1513,8 +1514,7 @@ function SearchPage() {
     }, [allAvailableHalls, fetchedDetails, locale])
 
     return (
-        <PublicLayout>
-            <section className="relative bg-surface-sunken">
+        <section className="relative bg-surface-sunken">
                 <div className="w-full md:flex md:items-stretch">
                     <div
                         aria-hidden="true"
@@ -1738,7 +1738,14 @@ function SearchPage() {
                         </div>
                     </div>
                 </div>
-            </section>
+        </section>
+    )
+}
+
+function SearchPage() {
+    return (
+        <PublicLayout>
+            <SearchPageContent />
         </PublicLayout>
     )
 }

--- a/frontend/src/test/blogs/blogDetailPage.test.tsx
+++ b/frontend/src/test/blogs/blogDetailPage.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it, vi, beforeEach } from 'vitest'
 import type { ReactNode } from 'react'
 import BlogDetailPage from '../../pages/public/BlogDetailPage'
 import { getMessages } from '../../i18n'
+import { PublicMessagesContext } from '../../components/public/PublicMessagesContext'
 
 const apiGetMock = vi.hoisted(() => vi.fn())
 
@@ -16,7 +17,9 @@ vi.mock('../../api/client', () => ({
 }))
 
 vi.mock('../../components/public/PublicLayout', () => ({
-  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  default: ({ children }: { children: ReactNode }) => (
+    <PublicMessagesContext.Provider value={getMessages()}>{children}</PublicMessagesContext.Provider>
+  ),
 }))
 
 vi.mock('quill', () => {


### PR DESCRIPTION
#### 🔗 Related Issue

Closes #244
Type: refactor

___
#### 🐛 Description of Issue

PR #217 migrated the five public child components flagged by #146 (`PublicFooter`, `PublicHeroSearch`, `PublicLatestBlogPreview`, `PublicPopularTags`, `PublicRecentDigitized`) from `getMessages()` to `usePublicMessages()`. The pages and the carousel were intentionally left out of that PR to keep the diff mechanical and the review small. Reviewer follow-up on #217 ("would be good to add a follow-up that changes the pages and carousel to use the same method") tracked in #244.

This PR completes that follow-up for the files currently on `development`.

___
#### 🔧 What Has Changed

- `BlogDetailPage`: split into `BlogDetailPageContent` (uses `usePublicMessages()`) + `BlogDetailPage` outer wrapper that mounts `PublicLayout`. Test fixture for `PublicLayout` updated to provide `PublicMessagesContext` so the rendered content can read messages.
- `SearchPage`: split into `SearchPageContent` + `SearchPage` outer wrapper. Helpers `mapProductionToSearchEntry`, `mapBlogToSearchEntry`, and `getGenreLabel` previously called `getMessages(locale)` directly; they now take a `Messages['search']` (or `Messages['search']['genres']`) parameter so they remain pure and the component is the single owner of the messages read. `FilterPanel` and `MobileSearchForm` read the context directly since they render inside `PublicLayout`.
- `PublicCarousel`: same helper-parameterisation as `SearchPage`; component itself reads the context. Always rendered inside `HomePage`'s `PublicLayout`.

___
#### 🏗️ Design Choices

- **Why split pages into outer wrapper + content component:** public pages own their own `PublicLayout` wrapper. `usePublicMessages()` requires the provider to be mounted, and the page's top-level function runs *before* its returned `<PublicLayout>` JSX is rendered — so the hook can't be called there. The split mirrors the already-merged `ArchiveDetailPage` pattern (introduced in #215).
- **Why thread `searchMessages` / `genreLabels` into pure helpers instead of calling the hook deeper:** the helpers (`mapProductionToSearchEntry`, `mapBlogToSearchEntry`, `getGenreLabel`, `mapProductionToCarouselItem`) are pure mapping functions called inside `useMemo`/`useEffect`. They aren't React components, so they can't call hooks. Giving them a parameter keeps them pure and lets the component own a single hook read.
- **`getActiveLocale` left in place:** `withLocalePath`, route construction, and date formatting all need the URL-derived locale, not the messages bundle. Same reasoning as in #217 for `PublicFooter`.
- **`HomePage` deliberately not touched:** it imports only `getActiveLocale` (no `getMessages` calls); nothing to migrate.
- **`NotFoundPage` and `ArchiveDetailPage` not touched here:** both are introduced *and* already migrated by the open PR #215, so doing them again here would just produce conflicts.

___
#### 🧪 Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manually tested locally
- [x] No tests needed — explain why: behaviour-preserving refactor; the only test fixture change is the `PublicLayout` mock in `blogDetailPage.test.tsx` adding the messages provider so the migrated content can read messages. All 259 frontend tests pass.

`npm run lint`, `npm run build`, `npm test` all green locally. `npx tsc --noEmit` clean.

___
#### Manual testing instructions:

To verify this issue is resolved, a reviewer should:
1. `npm run dev` in `frontend/`, open `/` (home).
2. Toggle the locale (NL ↔ EN) using the navbar control. Confirm the carousel heading, subheading, "view all" link, loading and empty states all switch language together with no flash of stale text.
3. Visit `/zoeken`, toggle the locale, and confirm the filter panel labels, share button, results suffix, sort options, and tab labels all switch.
4. Open a blog detail page (e.g. `/nl/blogs/<id>` for any real blog), toggle the locale, and confirm the back link, loading text, untitled fallback, and "related productions" heading all switch.
5. Optional sanity check: `npm test` should be 259/259.

___
#### ✅ Pre-merge Checklist

- [x] Linked to a related issue above
- [x] My code follows the project's code style (`npm run lint` passes)
- [x] All existing tests still pass (`npm test` passes — 259/259)
- [x] New functionality is covered by tests (or wasn't needed: explained above)
- [x] I have reviewed my own diff before requesting review
- [ ] At least 2 reviewers have been assigned (auto-assigned, but verify)