### PR TITLE
Fix/278 fetch all event pages

### DIFF
--- a/frontend/src/api/blogs.ts
+++ b/frontend/src/api/blogs.ts
@@ -1,15 +1,46 @@
 import { api } from './client'
 import { z } from 'zod'
 
+type Meta = {
+    total: number
+    page: number
+    limit: number
+    totalPages: number
+}
+
+type PaginatedResponse<T> = {
+    data: T[]
+    meta: Meta
+}
+
 export const blogSchema = z.object({
     id: z.string().uuid(),
-    title: z.object({ nl: z.string().optional(), en: z.string().optional() }).nullable().optional(),
-    content: z.unknown().nullable().optional(),
-    created_at: z.coerce.date().optional(),
+    title: z.object({
+        nl: z.string().nullable().optional(),
+        en: z.string().nullable().optional(),
+    }).nullable().optional(),
+    content: z.record(z.string(), z.unknown()).nullable().optional(),
+    productions: z.array(z.string().uuid()),
+    created_at: z.coerce.date(),
+    updated_at: z.coerce.date(),
+    links: z.object({
+        self: z.string(),
+    }).optional(),
 })
 
 export type Blog = z.infer<typeof blogSchema>
 
-export const getBlogsByProductionId = (productionId: string) => {
-    return api.get<{ data: Blog[] }>(`/archive/blogs?productionId=${productionId}`)
+export const getBlogsByProductionId = async (productionId: string) => {
+    const first = await api.get<PaginatedResponse<Blog>>(`/archive/blogs?productionId=${productionId}&page=1`)
+    const { totalPages } = first.meta
+
+    if (totalPages <= 1) return { data: first.data }
+
+    const rest = await Promise.all(
+        Array.from({ length: totalPages - 1 }, (_, i) =>
+            api.get<PaginatedResponse<Blog>>(`/archive/blogs?productionId=${productionId}&page=${i + 2}`)
+        )
+    )
+
+    return { data: [...first.data, ...rest.flatMap((r) => r.data)] }
 }

--- a/frontend/src/api/events.ts
+++ b/frontend/src/api/events.ts
@@ -54,7 +54,7 @@ export const getEventsByProductionId = async (productionId: string) => {
     const first = await api.get<PaginatedResponse<Event>>(`/archive/events?productionId=${productionId}&page=1`)
     const { totalPages } = first.meta
 
-    if (totalPages <= 1) return first.data
+    if (totalPages <= 1) return { data: first.data }
 
     const rest = await Promise.all(
         Array.from({ length: totalPages - 1 }, (_, i) =>

--- a/frontend/src/api/events.ts
+++ b/frontend/src/api/events.ts
@@ -7,17 +7,60 @@ const localizedTextSchema = z.object({
     en: z.string().optional(),
 }).nullable()
 
+type Meta = {
+    total: number
+    page: number
+    limit: number
+    totalPages: number
+}
+
+type PaginatedResponse<T> = {
+    data: T[]
+    meta: Meta
+}
+
 export const eventSchema = z.object({
     id: z.string().uuid(),
+    apiId: z.string().nullable(),
     starts_at: z.coerce.date().nullable(),
     ends_at: z.coerce.date().nullable(),
+    intermission_at: z.coerce.date().nullable(),
     doors_at: z.coerce.date().nullable(),
+    box_office_id: z.string().nullable(),
+    vendor_id: z.string().nullable(),
+    max_tickets_per_order: z.number().int().nullable(),
+    secure: z.boolean().nullable(),
+    sms_verification: z.boolean().nullable(),
     info: localizedTextSchema,
+    eticket_info: localizedTextSchema,
+    external_order_url: localizedTextSchema,
+    order_url: z.string().nullable(),
     production_id: z.string().uuid().nullable(),
+    status_id: z.string().uuid().nullable(),
     hall_id: z.string().uuid().nullable(),
+    created_at: z.coerce.date(),
+    updated_at: z.coerce.date(),
+    links: z.object({
+        self: z.string(),
+        production: z.string().nullable().optional(),
+        hall: z.string().nullable().optional(),
+        prices: z.string().nullable().optional(),
+    }).optional(),
 })
 
 export type Event = z.infer<typeof eventSchema>
 
-export const getEventsByProductionId = (productionId: string) =>
-    api.get<{ data: Event[] }>(`/archive/events?productionId=${productionId}`)
+export const getEventsByProductionId = async (productionId: string) => {
+    const first = await api.get<PaginatedResponse<Event>>(`/archive/events?productionId=${productionId}&page=1`)
+    const { totalPages } = first.meta
+
+    if (totalPages <= 1) return first.data
+
+    const rest = await Promise.all(
+        Array.from({ length: totalPages - 1 }, (_, i) =>
+            api.get<PaginatedResponse<Event>>(`/archive/events?productionId=${productionId}&page=${i + 2}`)
+        )
+    )
+
+    return { data: [...first.data, ...rest.flatMap((r) => r.data)] }
+}

--- a/frontend/src/api/genres.ts
+++ b/frontend/src/api/genres.ts
@@ -7,6 +7,18 @@ const localizedTextSchema = z.object({
     en: z.string().optional(),
 }).nullable()
 
+type Meta = {
+    total: number
+    page: number
+    limit: number
+    totalPages: number
+}
+
+type PaginatedResponse<T> = {
+    data: T[]
+    meta: Meta
+}
+
 export const genreSchema = z.object({
     id: z.string().uuid(),
     apiId: z.string().nullable(),
@@ -15,9 +27,29 @@ export const genreSchema = z.object({
     name: localizedTextSchema,
     slug: localizedTextSchema,
     description: localizedTextSchema,
+    created_at: z.coerce.date(),
+    updated_at: z.coerce.date(),
+    links: z.object({
+        self: z.string(),
+        productions: z.string().nullable().optional(),
+        hall: z.string().nullable().optional(),
+        prices: z.string().nullable().optional(),
+    }).optional(),
 })
 
 export type Genre = z.infer<typeof genreSchema>
 
-export const getGenresByProductionId = (productionId: string) =>
-    api.get<{ data: Genre[] }>(`/archive/genres?productionId=${productionId}`)
+export const getGenresByProductionId = async (productionId: string) => {
+    const first = await api.get<PaginatedResponse<Genre>>(`/archive/genres?productionId=${productionId}&page=1`)
+    const { totalPages } = first.meta
+
+    if (totalPages <= 1) return { data: first.data }
+
+    const rest = await Promise.all(
+        Array.from({ length: totalPages - 1 }, (_, i) =>
+            api.get<PaginatedResponse<Genre>>(`/archive/genres?productionId=${productionId}&page=${i + 2}`)
+        )
+    )
+
+    return { data: [...first.data, ...rest.flatMap((r) => r.data)] }
+}

--- a/frontend/src/api/tags.ts
+++ b/frontend/src/api/tags.ts
@@ -7,6 +7,18 @@ const localizedTextSchema = z.object({
     en: z.string().optional(),
 }).nullable()
 
+type Meta = {
+    total: number
+    page: number
+    limit: number
+    totalPages: number
+}
+
+type PaginatedResponse<T> = {
+    data: T[]
+    meta: Meta
+}
+
 export const tagSchema = z.object({
     id: z.string().uuid(),
     apiId: z.string().nullable(),
@@ -15,9 +27,27 @@ export const tagSchema = z.object({
     name: localizedTextSchema,
     slug: localizedTextSchema,
     description: localizedTextSchema,
+    created_at: z.coerce.date(),
+    updated_at: z.coerce.date(),
+    links: z.object({
+        self: z.string(),
+        productions: z.string().nullable().optional(),
+    }).optional(),
 })
 
 export type Tag = z.infer<typeof tagSchema>
 
-export const getTagsByProductionId = (productionId: string) =>
-    api.get<{ data: Tag[] }>(`/archive/tags?productionId=${productionId}`)
+export const getTagsByProductionId = async (productionId: string) => {
+    const first = await api.get<PaginatedResponse<Tag>>(`/archive/tags?productionId=${productionId}&page=1`)
+    const { totalPages } = first.meta
+
+    if (totalPages <= 1) return { data: first.data }
+
+    const rest = await Promise.all(
+        Array.from({ length: totalPages - 1 }, (_, i) =>
+            api.get<PaginatedResponse<Tag>>(`/archive/tags?productionId=${productionId}&page=${i + 2}`)
+        )
+    )
+
+    return { data: [...first.data, ...rest.flatMap((r) => r.data)] }
+}

--- a/frontend/src/test/api/blogs.test.ts
+++ b/frontend/src/test/api/blogs.test.ts
@@ -29,7 +29,7 @@ describe('blogs api', () => {
         const result = await getBlogsByProductionId('dab70000-0000-0000-0000-000000000001')
 
         expect(fetchMock).toHaveBeenCalledWith(
-            '/api/v1/archive/blogs?productionId=dab70000-0000-0000-0000-000000000001',
+            '/api/v1/archive/blogs?productionId=dab70000-0000-0000-0000-000000000001&page=1',
             expect.objectContaining({ credentials: 'include' }),
         )
         expect(result.data).toHaveLength(1)

--- a/frontend/src/test/api/events.test.ts
+++ b/frontend/src/test/api/events.test.ts
@@ -25,13 +25,19 @@ describe('events api', () => {
                         hall_id: '214a0000-0000-0000-0000-000000000001',
                     },
                 ],
+                meta: {
+                    total: 1,
+                    page: 1,
+                    limit: 20,
+                    totalPages: 1,
+                },
             }),
         } as unknown as Response)
 
         const result = await getEventsByProductionId('dab70000-0000-0000-0000-000000000001')
 
         expect(fetchMock).toHaveBeenCalledWith(
-            '/api/v1/archive/events?productionId=dab70000-0000-0000-0000-000000000001',
+            '/api/v1/archive/events?productionId=dab70000-0000-0000-0000-000000000001&page=1',
             expect.objectContaining({ credentials: 'include' }),
         )
         expect(result.data).toHaveLength(1)
@@ -43,7 +49,7 @@ describe('events api', () => {
         fetchMock.mockResolvedValueOnce({
             ok: true,
             status: 200,
-            json: vi.fn().mockResolvedValueOnce({ data: [] }),
+            json: vi.fn().mockResolvedValueOnce({ data: [], meta: { total: 0, page: 1, limit: 20, totalPages: 1 } }),
         } as unknown as Response)
 
         const result = await getEventsByProductionId('dab70000-0000-0000-0000-000000000001')

--- a/frontend/src/test/api/genres.test.ts
+++ b/frontend/src/test/api/genres.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getGenresByProductionId } from '../../api/genres'
+ 
+const fetchMock = vi.fn()
+vi.stubGlobal('fetch', fetchMock)
+ 
+const baseGenre = {
+    id: 'c1000000-0000-0000-0000-000000000001',
+    apiId: null,
+    type: 'genre',
+    vendor_id: null,
+    name: { nl: 'Test genre', en: 'Test genre' },
+    slug: { nl: 'test-genre', en: 'test-genre' },
+    description: null,
+    created_at: '2026-04-01T10:00:00.000Z',
+    updated_at: '2026-04-01T10:00:00.000Z',
+    links: { self: 'http://localhost:3001/api/v1/archive/genres/c1000000-0000-0000-0000-000000000001' },
+}
+ 
+describe('genres api', () => {
+    beforeEach(() => {
+        fetchMock.mockReset()
+    })
+ 
+    it('fetches genres by productionId from the correct endpoint', async () => {
+        fetchMock.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: vi.fn().mockResolvedValueOnce({
+                data: [baseGenre],
+                meta: { total: 1, page: 1, limit: 20, totalPages: 1 },
+            }),
+        } as unknown as Response)
+ 
+        const result = await getGenresByProductionId('dab70000-0000-0000-0000-000000000001')
+ 
+        expect(fetchMock).toHaveBeenCalledWith(
+            '/api/v1/archive/genres?productionId=dab70000-0000-0000-0000-000000000001&page=1',
+            expect.objectContaining({ credentials: 'include' }),
+        )
+        expect(result.data).toHaveLength(1)
+        expect(result.data[0].id).toBe('c1000000-0000-0000-0000-000000000001')
+    })
+ 
+    it('returns an empty list when no genres are linked to the production', async () => {
+        fetchMock.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: vi.fn().mockResolvedValueOnce({
+                data: [],
+                meta: { total: 0, page: 1, limit: 20, totalPages: 0 },
+            }),
+        } as unknown as Response)
+ 
+        const result = await getGenresByProductionId('dab70000-0000-0000-0000-000000000001')
+ 
+        expect(result.data).toHaveLength(0)
+    })
+ 
+    it('fetches all pages when totalPages is greater than 1', async () => {
+        fetchMock
+            .mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                json: vi.fn().mockResolvedValueOnce({
+                    data: [baseGenre],
+                    meta: { total: 2, page: 1, limit: 1, totalPages: 2 },
+                }),
+            } as unknown as Response)
+            .mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                json: vi.fn().mockResolvedValueOnce({
+                    data: [{ ...baseGenre, id: 'c1000000-0000-0000-0000-000000000002' }],
+                    meta: { total: 2, page: 2, limit: 1, totalPages: 2 },
+                }),
+            } as unknown as Response)
+ 
+        const result = await getGenresByProductionId('dab70000-0000-0000-0000-000000000001')
+ 
+        expect(result.data).toHaveLength(2)
+        expect(fetchMock).toHaveBeenCalledTimes(2)
+    })
+ 
+    it('throws when the server returns an error status', async () => {
+        fetchMock.mockResolvedValueOnce({
+            ok: false,
+            status: 500,
+            json: vi.fn().mockResolvedValueOnce({ message: 'Internal server error' }),
+        } as unknown as Response)
+ 
+        await expect(getGenresByProductionId('dab70000-0000-0000-0000-000000000001')).rejects.toThrow()
+    })
+})

--- a/frontend/src/test/api/tags.test.ts
+++ b/frontend/src/test/api/tags.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getTagsByProductionId } from '../../api/tags'
+ 
+const fetchMock = vi.fn()
+vi.stubGlobal('fetch', fetchMock)
+ 
+const baseTag = {
+    id: 'a1000000-0000-0000-0000-000000000001',
+    apiId: null,
+    type: 'genre',
+    vendor_id: null,
+    name: { nl: 'Test tag', en: 'Test tag' },
+    slug: { nl: 'test-tag', en: 'test-tag' },
+    description: null,
+    created_at: '2026-04-01T10:00:00.000Z',
+    updated_at: '2026-04-01T10:00:00.000Z',
+    links: { self: 'http://localhost:3001/api/v1/archive/tags/a1000000-0000-0000-0000-000000000001' },
+}
+ 
+describe('tags api', () => {
+    beforeEach(() => {
+        fetchMock.mockReset()
+    })
+ 
+    it('fetches tags by productionId from the correct endpoint', async () => {
+        fetchMock.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: vi.fn().mockResolvedValueOnce({
+                data: [baseTag],
+                meta: { total: 1, page: 1, limit: 20, totalPages: 1 },
+            }),
+        } as unknown as Response)
+ 
+        const result = await getTagsByProductionId('dab70000-0000-0000-0000-000000000001')
+ 
+        expect(fetchMock).toHaveBeenCalledWith(
+            '/api/v1/archive/tags?productionId=dab70000-0000-0000-0000-000000000001&page=1',
+            expect.objectContaining({ credentials: 'include' }),
+        )
+        expect(result.data).toHaveLength(1)
+        expect(result.data[0].id).toBe('a1000000-0000-0000-0000-000000000001')
+    })
+ 
+    it('returns an empty list when no tags are linked to the production', async () => {
+        fetchMock.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: vi.fn().mockResolvedValueOnce({
+                data: [],
+                meta: { total: 0, page: 1, limit: 20, totalPages: 0 },
+            }),
+        } as unknown as Response)
+ 
+        const result = await getTagsByProductionId('dab70000-0000-0000-0000-000000000001')
+ 
+        expect(result.data).toHaveLength(0)
+    })
+ 
+    it('fetches all pages when totalPages is greater than 1', async () => {
+        fetchMock
+            .mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                json: vi.fn().mockResolvedValueOnce({
+                    data: [baseTag],
+                    meta: { total: 2, page: 1, limit: 1, totalPages: 2 },
+                }),
+            } as unknown as Response)
+            .mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                json: vi.fn().mockResolvedValueOnce({
+                    data: [{ ...baseTag, id: 'a1000000-0000-0000-0000-000000000002' }],
+                    meta: { total: 2, page: 2, limit: 1, totalPages: 2 },
+                }),
+            } as unknown as Response)
+ 
+        const result = await getTagsByProductionId('dab70000-0000-0000-0000-000000000001')
+ 
+        expect(result.data).toHaveLength(2)
+        expect(fetchMock).toHaveBeenCalledTimes(2)
+    })
+ 
+    it('throws when the server returns an error status', async () => {
+        fetchMock.mockResolvedValueOnce({
+            ok: false,
+            status: 500,
+            json: vi.fn().mockResolvedValueOnce({ message: 'Internal server error' }),
+        } as unknown as Response)
+ 
+        await expect(getTagsByProductionId('dab70000-0000-0000-0000-000000000001')).rejects.toThrow()
+    })
+})

--- a/frontend/src/test/components/public/PublicDetailEventsList.test.tsx
+++ b/frontend/src/test/components/public/PublicDetailEventsList.test.tsx
@@ -21,12 +21,25 @@ vi.mock('../../../components/public/PublicMessagesContext', () => ({
 function makeEvent(overrides: Partial<Event> = {}): Event {
     return {
         id: crypto.randomUUID(),
+        apiId: null,
         starts_at: new Date('2027-03-06T13:00:00.000Z'),
         ends_at: new Date('2027-03-06T14:15:00.000Z'),
+        intermission_at: null,
         doors_at: null,
+        box_office_id: null,
+        vendor_id: null,
+        max_tickets_per_order: null,
+        secure: null,
+        sms_verification: null,
         info: null,
+        eticket_info: null,
+        external_order_url: null,
+        order_url: null,
         production_id: 'dab70000-0000-0000-0000-000000000001',
+        status_id: null,
         hall_id: '214a0000-0000-0000-0000-000000000001',
+        created_at: new Date('2026-04-01T10:00:00.000Z'),
+        updated_at: new Date('2026-04-01T10:00:00.000Z'),
         ...overrides,
     }
 }

--- a/frontend/src/test/components/public/PublicDetailHeroBanner.test.tsx
+++ b/frontend/src/test/components/public/PublicDetailHeroBanner.test.tsx
@@ -126,6 +126,8 @@ describe('ArchiveDetailHero', () => {
                         name: { nl: 'Concert', en: 'Concert' },
                         slug: { nl: 'muziek', en: 'music' },
                         description: null,
+                        created_at: new Date('2026-04-01T10:00:00.000Z'),
+                        updated_at: new Date('2026-04-01T10:00:00.000Z'),
                     },
                 ]}
             />
@@ -149,6 +151,8 @@ describe('ArchiveDetailHero', () => {
                         name: { nl: 'Concert', en: 'Concert' },
                         slug: { nl: 'muziek', en: 'music' },
                         description: null,
+                        created_at: new Date('2026-04-01T10:00:00.000Z'),
+                        updated_at: new Date('2026-04-01T10:00:00.000Z'),
                     },
                 ]}
             />
@@ -173,6 +177,8 @@ describe('ArchiveDetailHero', () => {
                         name: { nl: 'Concert', en: 'Concert' },
                         slug: { nl: 'muziek', en: 'music' },
                         description: null,
+                        created_at: new Date('2026-04-01T10:00:00.000Z'),
+                        updated_at: new Date('2026-04-01T10:00:00.000Z'),
                     },
                     {
                         id: '8edda54e-a1c4-486d-9fd4-c2e43cb2fe2f',
@@ -182,6 +188,8 @@ describe('ArchiveDetailHero', () => {
                         name: { nl: 'Performance', en: 'Performance' },
                         slug: { nl: 'performance', en: 'performance' },
                         description: null,
+                        created_at: new Date('2026-04-01T10:00:00.000Z'),
+                        updated_at: new Date('2026-04-01T10:00:00.000Z'),
                     },
                 ]}
             />
@@ -221,6 +229,8 @@ describe('ArchiveDetailHero', () => {
                         name: null,
                         slug: null,
                         description: null,
+                        created_at: new Date('2026-04-01T10:00:00.000Z'),
+                        updated_at: new Date('2026-04-01T10:00:00.000Z'),
                     },
                 ]}
             />
@@ -244,6 +254,8 @@ describe('ArchiveDetailHero', () => {
                         name: { nl: 'Concert', en: 'Concert EN' },
                         slug: null,
                         description: null,
+                        created_at: new Date('2026-04-01T10:00:00.000Z'),
+                        updated_at: new Date('2026-04-01T10:00:00.000Z'),
                     },
                 ]}
             />

--- a/frontend/src/utils/localize.ts
+++ b/frontend/src/utils/localize.ts
@@ -1,7 +1,7 @@
 type LocalizedField = {
-    nl?: string
-    fr?: string
-    en?: string
+    nl?: string | null
+    fr?: string | null
+    en?: string | null
 } | null | undefined
 
 export function localize(field: LocalizedField, locale: string): string | null {


### PR DESCRIPTION
<!--
  Thanks for opening a pull request!
  Fill in the sections below to help reviewers understand your changes quickly.
  Delete any section that genuinely does not apply.
-->

#### 🔗 Related Issue

Closes #278 <!-- issue number -->
Type: Bug <!-- What was the type of that issue? -->

___
#### 🐛 Description of Issue

<!--
  Briefly describe what the issue was that this PR solves.
  A reviewer should be able to understand the "why" without having to read the issue first.
-->

The Issue was that currently the production detail page only fetches one page of events (so 20 events max). If a production has more events than that they won't be shown. I noticed this also was the case for blogs, genres, and tags so updated these as well

___
#### 🔧 What Has Changed

<!--
  Summarise the changes you made. Focus on WHAT changed, not HOW
  (the code speaks for itself). Bullet points work well here.
-->

- updated `api/events.ts` so it fetches multiple pages if necessary when getting based on productionId
- updated `api/blogs.ts` so it fetches all pages
- updated `api/tags.ts` so it fetches all pages
- updated `api/genres.ts` so it fetches all pages
- updated + added tests for the above files.

___
#### 🏗️ Design Choices

<!--
  Explain the non-obvious decisions you made and why you made them.
  Were there alternatives you considered and rejected? Mention them here
  so reviewers understand the tradeoffs and do not suggest paths you already explored.
-->

- **Why X instead of Y:** ...
- **Trade-offs accepted:** ...

___
#### 🧪 Testing

<!--
  Describe how this change has been tested.
  Check all that apply.
-->

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] Manually tested locally
- [ ] No tests needed — explain why: ...

___
#### Manual testing instructions:

To verify this issue is resolved, a reviewer should:
1. `npm run dev` in both frontend and backend
2. look for a production with a lot of events (fe 'A Long Goodbye')
3. make sure all past events are shown properly.
4. make sure that genres, tags, and blogs still get fetched properly.

___
#### ✅ Pre-merge Checklist

<!--
  Go through this checklist before marking the PR as ready for review.
  All boxes must be checked before merging (the branch protection rules will enforce most of these,
  but this checklist serves as a reminder and a paper trail).
-->

- [x] Linked to a related issue above
- [x] My code follows the project's code style (`npm run lint` passes)
- [x] All existing tests still pass (`npm test` passes)
- [x] New functionality is covered by tests (or wasn't needed: explained!)
- [x] I have reviewed my own diff before requesting review
- [x] At least 2 reviewers have been assigned (auto-assigned, but verify)

---

## 📸 Screenshots / Demo *(optional)*

<!-- If your change affects the UI, attach a before/after screenshot or a short screen recording. -->

