### PR TITLE
340 fix image op homepage   blog

### DIFF
--- a/frontend/src/api/blogs.ts
+++ b/frontend/src/api/blogs.ts
@@ -25,8 +25,8 @@ export const blogSchema = z.object({
         .nullable()
         .optional(),
     content: z.record(z.string(), z.unknown()).nullable().optional(),
-    images: z.array(z.string()).default([]),
-    thumbnail_index: z.number().int().nonnegative().default(0),
+    images: z.array(z.string()).optional(),
+    thumbnail_index: z.number().int().nonnegative().optional(),
     productions: z.array(z.string()).optional(),
     created_at: z.coerce.date().optional(),
     updated_at: z.coerce.date().optional(),

--- a/frontend/src/api/blogs.ts
+++ b/frontend/src/api/blogs.ts
@@ -25,6 +25,8 @@ export const blogSchema = z.object({
         .nullable()
         .optional(),
     content: z.record(z.string(), z.unknown()).nullable().optional(),
+    images: z.array(z.string()).default([]),
+    thumbnail_index: z.number().int().nonnegative().default(0),
     productions: z.array(z.string()).optional(),
     created_at: z.coerce.date().optional(),
     updated_at: z.coerce.date().optional(),

--- a/frontend/src/components/public/PublicLatestBlogPreview.tsx
+++ b/frontend/src/components/public/PublicLatestBlogPreview.tsx
@@ -33,17 +33,24 @@ function PublicLatestBlogPreview({ blog, locale, fallbackUntitled, onReadMore, o
 
     const excerpt = excerptRaw.length > 320 ? `${excerptRaw.slice(0, 317)}...` : excerptRaw
 
+    let previewImageSrc = ''
+    let previewImageClassName = 'h-full w-full object-cover'
+    
+    // If no valid thumbnail, select fallback image
+    if (blog.images.length > 0 && blog.thumbnail_index >= 0 && blog.thumbnail_index < blog.images.length) {
+        previewImageSrc = blog.images[blog.thumbnail_index]
+    } else {
+        previewImageSrc = '/fallback-hero.svg'
+        previewImageClassName = 'h-full w-full object-cover opacity-70'
+    }
+
     return (
         <section className="py-16 bg-foreground/3">
             <SectionTitle title={messages.home.latestBlogHeading} subtitle={messages.home.latestBlogSubheading} />
 
             <article className="site-container grid items-stretch gap-12 lg:grid-cols-[1fr_auto_1.1fr]">
                 <div className="relative h-[420px] overflow-hidden border border-border bg-surface sm:h-[560px]" aria-hidden="true">
-                    <img
-                        src={blog.images[blog.thumbnail_index]}
-                        alt=""
-                        className="h-full w-full object-cover"
-                    />
+                    <img src={previewImageSrc} alt="" className={previewImageClassName} />
                 </div>
                 <div aria-hidden className="hidden w-px self-stretch bg-foreground/25 lg:block" />
 

--- a/frontend/src/components/public/PublicLatestBlogPreview.tsx
+++ b/frontend/src/components/public/PublicLatestBlogPreview.tsx
@@ -40,9 +40,9 @@ function PublicLatestBlogPreview({ blog, locale, fallbackUntitled, onReadMore, o
             <article className="site-container grid items-stretch gap-12 lg:grid-cols-[1fr_auto_1.1fr]">
                 <div className="relative h-[420px] overflow-hidden border border-border bg-surface sm:h-[560px]" aria-hidden="true">
                     <img
-                        src="/fallback-hero.svg"
+                        src={blog.images[blog.thumbnail_index]}
                         alt=""
-                        className="h-full w-full object-cover opacity-70"
+                        className="h-full w-full object-cover"
                     />
                 </div>
                 <div aria-hidden className="hidden w-px self-stretch bg-foreground/25 lg:block" />

--- a/frontend/src/components/public/PublicLatestBlogPreview.tsx
+++ b/frontend/src/components/public/PublicLatestBlogPreview.tsx
@@ -37,7 +37,7 @@ function PublicLatestBlogPreview({ blog, locale, fallbackUntitled, onReadMore, o
     let previewImageClassName = 'h-full w-full object-cover'
     
     // If no valid thumbnail, select fallback image
-    if (blog.images.length > 0 && blog.thumbnail_index >= 0 && blog.thumbnail_index < blog.images.length) {
+    if (blog.images && blog.images.length > 0 && blog.thumbnail_index >= 0 && blog.thumbnail_index < blog.images.length) {
         previewImageSrc = blog.images[blog.thumbnail_index]
     } else {
         previewImageSrc = '/fallback-hero.svg'

--- a/frontend/src/components/public/PublicLatestBlogPreview.tsx
+++ b/frontend/src/components/public/PublicLatestBlogPreview.tsx
@@ -37,7 +37,7 @@ function PublicLatestBlogPreview({ blog, locale, fallbackUntitled, onReadMore, o
     let previewImageClassName = 'h-full w-full object-cover'
     
     // If no valid thumbnail, select fallback image
-    if (blog.images && blog.images.length > 0 && blog.thumbnail_index >= 0 && blog.thumbnail_index < blog.images.length) {
+    if (blog.images && blog.thumbnail_index && blog.images.length > 0 && blog.thumbnail_index >= 0 && blog.thumbnail_index < blog.images.length) {
         previewImageSrc = blog.images[blog.thumbnail_index]
     } else {
         previewImageSrc = '/fallback-hero.svg'


### PR DESCRIPTION
<!--
  Thanks for opening a pull request!
  Fill in the sections below to help reviewers understand your changes quickly.
  Delete any section that genuinely does not apply.
-->

#### 🔗 Related Issue

Closes #340
Type: Feature

___
#### 🐛 Description of Issue

The blog image was not visable on the homepage

___
#### 🔧 What Has Changed


- Update blogs.ts to contain images and thumbnail index
- Changed image URL in PublicLatestBlogpreview

___
#### 🏗️ Design Choices

<!--
  Explain the non-obvious decisions you made and why you made them.
  Were there alternatives you considered and rejected? Mention them here
  so reviewers understand the tradeoffs and do not suggest paths you already explored.
-->

- Only show t
- **Trade-offs accepted:** ...

___
#### 🧪 Testing

<!--
  Describe how this change has been tested.
  Check all that apply.
-->

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manually tested locally
- [ ] No tests needed — explain why: ...

___
#### Manual testing instructions:

To verify this issue is resolved, a reviewer should:
1. Make a blog with image cover
2. Go to the homepage and see the cover
3.Also test blogs without an image

___
#### ✅ Pre-merge Checklist

<!--
  Go through this checklist before marking the PR as ready for review.
  All boxes must be checked before merging (the branch protection rules will enforce most of these,
  but this checklist serves as a reminder and a paper trail).
-->

- [ ] Linked to a related issue above
- [ ] My code follows the project's code style (`npm run lint` passes)
- [ ] All existing tests still pass (`npm test` passes)
- [ ] New functionality is covered by tests (or wasn't needed: explained!)
- [ ] I have reviewed my own diff before requesting review
- [ ] At least 2 reviewers have been assigned (auto-assigned, but verify)

---

## 📸 Screenshots / Demo *(optional)*

<!-- If your change affects the UI, attach a before/after screenshot or a short screen recording. -->

